### PR TITLE
Add linux install script

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -98,9 +98,5 @@ background and submit data to Vanta.
 
 You can check the agent status using the \"vanta-cli status\" command.
 
-If you ever want to stop the agent, please use the toolbar icon or
-the launchctl command. It will restart automatically at login.
-
-To register this device to a new user, run \"vanta-cli register\" or click on \"Register Vanta Agent\"
-on the toolber.
+To register this device to a new user, run \"vanta-cli register\".
 \033[0m"

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -65,8 +65,8 @@ background and submit data to Vanta.
 You can check the agent status using the \"vanta-cli status\" command.
 
 If you ever want to stop the agent, please use the toolbar icon or
-the launchctl command. It will restart automatically at login.
+the vanta-cli command. It will restart automatically at login.
 
 To register this device to a new user, run \"vanta-cli register\" or click on \"Register Vanta Agent\"
-on the toolber.
+on the toolbar.
 \033[0m"


### PR DESCRIPTION
Add linux installation script and clean up macOS installation script.

This allows people to install directly from s3 without a custom-bundled installer.

`VANTA_AGENT_KEY=<your key> bash -c "$(curl -L <path_to_this_script>)"` will install the agent!

The actual s3 urls (latest, currently) will be changed to a specific version before we make this repo public.