### PR TITLE
Add windows installer check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,26 @@ jobs:
         
   build-macos:
 
-    runs-on: macOS-latest
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v1
-    - name: Test install on Macos
+    - name: Test install on macOS
       run: |
         chmod +x ./install-macos.sh
         VANTA_KEY=FAKEKEY ./install-macos.sh
     - name: Check that it's running correctly
       run: vanta-cli status
+  
+  build-windows:
+    
+    runs-on: windows-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Test install on Windows
+      run: |
+        install-vanta.bat fakekey name@example.com
+    - name: Check that it's running correctly
+      run: vanta-cli status
+        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         VANTA_KEY=FAKEKEY ./install-linux.sh
     - name: Check that it's running correctly
       run: vanta-cli status
-        
+
   build-macos:
 
     runs-on: macos-latest
@@ -28,20 +28,18 @@ jobs:
         VANTA_KEY=FAKEKEY ./install-macos.sh
     - name: Check that it's running correctly
       run: vanta-cli status
-  
+
   build-windows:
-    
+
     runs-on: windows-latest
-    
+
     steps:
     - uses: actions/checkout@v1
     - name: Test install on Windows
       shell: cmd
       run: |
         install-vanta.bat fakekey name@example.com
-    - name: Check that it's running correctly
+    - name: Check that the directory exists
       shell: cmd
       run: |
         dir C:\ProgramData\Vanta
-        C:\ProgramData\Vanta\vanta-cli.exe status
-        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Test install on Windows
+      shell: cmd
       run: |
         install-vanta.bat fakekey name@example.com
     - name: Check that it's running correctly
+      shell: cmd
       run: vanta-cli status
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,5 +41,5 @@ jobs:
         install-vanta.bat fakekey name@example.com
     - name: Check that it's running correctly
       shell: cmd
-      run: vanta-cli status
+      run: C:\ProgramData\Vanta\vanta-cli status
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,5 +41,7 @@ jobs:
         install-vanta.bat fakekey name@example.com
     - name: Check that it's running correctly
       shell: cmd
-      run: C:\ProgramData\Vanta\vanta-cli status
+      run: |
+        dir C:\ProgramData\Vanta
+        C:\ProgramData\Vanta\vanta-cli.exe status
         

--- a/install-vanta.bat
+++ b/install-vanta.bat
@@ -4,7 +4,7 @@ IF "%~2"=="" goto :needparams
 IF NOT "%~3"=="" goto :needparams
 
 :: download Vanta
-curl -o vanta-installer.exe https://vanta-agent.s3.amazonaws.com/v0.1.2/vanta-installer.exe
+curl -o vanta-installer.exe https://vanta-agent.s3.amazonaws.com/v0.2.0/vanta-installer.exe
 
 :: write config files
 mkdir C:\ProgramData\Vanta

--- a/install-vanta.bat
+++ b/install-vanta.bat
@@ -4,7 +4,7 @@ IF "%~2"=="" goto :needparams
 IF NOT "%~3"=="" goto :needparams
 
 :: download Vanta
-curl -o vanta-installer.exe https://vanta-agent.s3.amazonaws.com/v0.2.0/vanta-installer.exe
+curl -o vanta-installer.exe https://vanta-agent.s3.amazonaws.com/v0.1.2/vanta-installer.exe
 
 :: write config files
 mkdir C:\ProgramData\Vanta


### PR DESCRIPTION
We had a bug in the windows installer script that we didn't catch at release-time since we didn't have any CI on that script.

This PR adds a basic sanity check; will add `vanta-cli doctor` to all three once we upgrade to 0.2.0.