### PR TITLE
upgrade scripts to install v1.3.1

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -6,11 +6,11 @@
 
 set -e
 
-DEB_URL="https://vanta-agent.s3.amazonaws.com/v0.2.0/vanta.deb"
-RPM_URL="https://vanta-agent.s3.amazonaws.com/v0.2.0/vanta.rpm"
-# Checksums for v0.2.0; need to be updated when PKG_URL is updated.
-DEB_CHECKSUM="5ccccd8fd340cb184916cb27cece31eeeaabd54035753bbae9d44ba6a8bc09ec"
-RPM_CHECKSUM="4482334672b609c7997a4b9d04d89f84189af9e2d9b18a98d3cac08ab68b22b0"
+DEB_URL="https://vanta-agent.s3.amazonaws.com/v1.3.1/vanta.deb"
+RPM_URL="https://vanta-agent.s3.amazonaws.com/v1.3.1/vanta.rpm"
+# Checksums for v1.3.1; need to be updated when PKG_URL is updated.
+DEB_CHECKSUM="9ef79b1c8bdcfe2e74c6747a16a8c741e980d453ff490addc3f9170d71b6bd6b"
+RPM_CHECKSUM="c2435b4cfad50be9daa21d95c7622f926474ae4ae1957f67e8ff47283b9a15c6"
 DEB_PATH="/tmp/vanta.deb"
 RPM_PATH="/tmp/vanta.rpm"
 DEB_INSTALL_CMD="dpkg -i"

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -5,9 +5,9 @@ set -e
 # VANTA_KEY (the Vanta per-domain secret key)
 # VANTA_OWNER_EMAIL (the email of the person who owns this computer. Ignored if VANTA_KEY is missing.)
 
-PKG_URL="https://vanta-agent.s3.amazonaws.com/v0.2.0/vanta.pkg"
+PKG_URL="https://vanta-agent.s3.amazonaws.com/v1.3.1/vanta.pkg"
 # Checksum for v0.2.0; needs to be updated when PKG_URL is updated.
-CHECKSUM="57985bd4313a16848bbeada1ec711cd35f4748c7b333f87f32fc2413bf191cd3"
+CHECKSUM="c6cc530d29dc6102fe52b2a4c12778b1cb8dcb9c5cb0700c3b72725501f52c05"
 PKG_PATH="/tmp/vanta.pkg"
 
 ##

--- a/install-vanta.bat
+++ b/install-vanta.bat
@@ -4,12 +4,11 @@ IF "%~2"=="" goto :needparams
 IF NOT "%~3"=="" goto :needparams
 
 :: download Vanta
-curl -o vanta-installer.exe https://vanta-agent.s3.amazonaws.com/v0.2.0/vanta-installer.exe
+curl -o vanta-installer.exe https://vanta-agent.s3.amazonaws.com/v1.3.1/vanta-installer.exe
 
 :: write config files
 mkdir C:\ProgramData\Vanta
-echo {"AGENT_KEY": "%1", "NEEDS_OWNER": true, "OWNER_EMAIL": "%2"} > C:\ProgramData\Vanta\enroll_secret.txt
-copy C:\ProgramData\Vanta\enroll_secret.txt C:\ProgramData\Vanta\vanta.conf
+echo {"AGENT_KEY": "%1", "NEEDS_OWNER": true, "OWNER_EMAIL": "%2"} > C:\ProgramData\Vanta\vanta.conf
 
 :: set permissions on config files so installer doesn't overwrite
 icacls C:\ProgramData\Vanta\enroll_secret.txt /grant Everyone:R
@@ -19,10 +18,6 @@ icacls C:\ProgramData\Vanta\vanta.conf /deny Everyone:W
 
 :: install vanta
 vanta-installer.exe /S
-
-:: remove permissions on Everyone
-icacls C:\ProgramData\Vanta\enroll_secret.txt /remove Everyone
-icacls C:\ProgramData\Vanta\vanta.conf /remove Everyone
 
 EXIT
 


### PR DESCRIPTION
Update scripts to install v1.3.1

We'll point this to `latest` once we can verify signatures on latest, but for now still using checksums.

Also remove old enroll_secret.txt cruft from the Windows script, since it isn't used anymore.

~To be merged once the checklist at https://github.com/VantaInc/vanta-agent/releases/tag/1.3.1 is complete.~ This is ready to be merged; 1.3.1 is at 100%.