### PR TITLE
add -E flag to dpkg

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -13,7 +13,7 @@ DEB_CHECKSUM="5ccccd8fd340cb184916cb27cece31eeeaabd54035753bbae9d44ba6a8bc09ec"
 RPM_CHECKSUM="4482334672b609c7997a4b9d04d89f84189af9e2d9b18a98d3cac08ab68b22b0"
 DEB_PATH="/tmp/vanta.deb"
 RPM_PATH="/tmp/vanta.rpm"
-DEB_INSTALL_CMD="dpkg -i"
+DEB_INSTALL_CMD="dpkg -Ei"
 RPM_INSTALL_CMD="rpm -i"
 
 # OS/Distro Detection


### PR DESCRIPTION
`dpkg -i` always installs the package, even if the version already exists.

One of the lifecycle management scripts in 1.3.1 is failing if we re-attempt to install 1.3.1 over itself.

Change to `dpkg -Ei`, which skips install if the current version is already installed.