### PR TITLE
upgrade targets to 1.4.0

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -6,14 +6,14 @@
 
 set -e
 
-DEB_URL="https://vanta-agent.s3.amazonaws.com/v1.3.1/vanta.deb"
-RPM_URL="https://vanta-agent.s3.amazonaws.com/v1.3.1/vanta.rpm"
-# Checksums for v1.3.1; need to be updated when PKG_URL is updated.
-DEB_CHECKSUM="9ef79b1c8bdcfe2e74c6747a16a8c741e980d453ff490addc3f9170d71b6bd6b"
-RPM_CHECKSUM="c2435b4cfad50be9daa21d95c7622f926474ae4ae1957f67e8ff47283b9a15c6"
+DEB_URL="https://vanta-agent.s3.amazonaws.com/v1.4.0/vanta.deb"
+RPM_URL="https://vanta-agent.s3.amazonaws.com/v1.4.0/vanta.rpm"
+# Checksums for v1.4.0; need to be updated when PKG_URL is updated.
+DEB_CHECKSUM="abb6fbadebbf8179e349d0a54257829b386dabe0b76e6b195ddd3b05f552cd74"
+RPM_CHECKSUM="10cea2622bf286c224a71b63b9b626ec387a80f4f7699f15e7da86bce0879415"
 DEB_PATH="/tmp/vanta.deb"
 RPM_PATH="/tmp/vanta.rpm"
-DEB_INSTALL_CMD="dpkg -Ei"
+DEB_INSTALL_CMD="dpkg -i" # change to -Ei if you don't want to reinstall over the same version
 RPM_INSTALL_CMD="rpm -i"
 
 # OS/Distro Detection

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -5,9 +5,9 @@ set -e
 # VANTA_KEY (the Vanta per-domain secret key)
 # VANTA_OWNER_EMAIL (the email of the person who owns this computer. Ignored if VANTA_KEY is missing.)
 
-PKG_URL="https://vanta-agent.s3.amazonaws.com/v1.3.1/vanta.pkg"
-# Checksum for v0.2.0; needs to be updated when PKG_URL is updated.
-CHECKSUM="c6cc530d29dc6102fe52b2a4c12778b1cb8dcb9c5cb0700c3b72725501f52c05"
+PKG_URL="https://vanta-agent.s3.amazonaws.com/v1.4.0/vanta.pkg"
+# Checksum for v1.4.0; needs to be updated when PKG_URL is updated.
+CHECKSUM="fccee38d2a41643968e70e7e5bfb4eeb05dc9d27fbec0dedbd3a0f76a58c0d45"
 PKG_PATH="/tmp/vanta.pkg"
 
 ##

--- a/install-vanta.bat
+++ b/install-vanta.bat
@@ -4,7 +4,7 @@ IF "%~2"=="" goto :needparams
 IF NOT "%~3"=="" goto :needparams
 
 :: download Vanta
-curl -o vanta-installer.exe https://vanta-agent.s3.amazonaws.com/v1.3.1/vanta-installer.exe
+curl -o vanta-installer.exe https://vanta-agent.s3.amazonaws.com/v1.4.0/vanta-installer.exe
 
 :: write config files
 mkdir C:\ProgramData\Vanta


### PR DESCRIPTION
Also temporarily revert the change that adds -E to the dpkg command, since we need the scripts on 1.4.0 to run twice on machines that have partially uninstalled.