### PR TITLE
use full path in case /usr/local/bin isn't on their path

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -73,7 +73,7 @@ rm -f $PKG_PATH
 # return val 0 means running,
 # return val 2 means running but needs to register
 ##
-$SUDO vanta-cli status || [ $? == 2 ]
+$SUDO /usr/local/vanta/vanta-cli status || [ $? == 2 ]
 
 printf "\033[32m
 Your Agent is running properly. It will continue to run in the


### PR DESCRIPTION
If `/usr/local/bin` isn't on the user's path, `vanta-cli` won't be found after installation.

Use full path to Vanta install.