### PR TITLE
bump version to 1.5.0

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -6,11 +6,11 @@
 
 set -e
 
-DEB_URL="https://vanta-agent.s3.amazonaws.com/v1.4.1/vanta.deb"
-RPM_URL="https://vanta-agent.s3.amazonaws.com/v1.4.1/vanta.rpm"
-# Checksums for v1.4.1; need to be updated when PKG_URL is updated.
-DEB_CHECKSUM="a59d8b3f143012e5f6fe90fd7f65a9301db56570857b015deec6c4e4399bdd9b"
-RPM_CHECKSUM="9e482f5e112e5070153f609896d91f69a73a5b6fa21432b56c8cec04c5fec77b"
+DEB_URL="https://vanta-agent.s3.amazonaws.com/v1.5.0/vanta.deb"
+RPM_URL="https://vanta-agent.s3.amazonaws.com/v1.5.0/vanta.rpm"
+# Checksums for v1.5.0; need to be updated when PKG_URL is updated.
+DEB_CHECKSUM="44c064961309e9907c4ae5988212d452a873f9a3e75f0c8129ad53ae8f119798"
+RPM_CHECKSUM="fd438f60466fd51d66340f7de8db028c165f2b704c7c766686c6e7b839315f6b"
 DEB_PATH="/tmp/vanta.deb"
 RPM_PATH="/tmp/vanta.rpm"
 DEB_INSTALL_CMD="dpkg -Ei"

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -5,9 +5,9 @@ set -e
 # VANTA_KEY (the Vanta per-domain secret key)
 # VANTA_OWNER_EMAIL (the email of the person who owns this computer. Ignored if VANTA_KEY is missing.)
 
-PKG_URL="https://vanta-agent.s3.amazonaws.com/v1.4.1/vanta.pkg"
-# Checksum for v1.4.1; needs to be updated when PKG_URL is updated.
-CHECKSUM="451aba7202128c6a69d7183811b306e410bc118c010aa1b7d7256a8552134631"
+PKG_URL="https://vanta-agent.s3.amazonaws.com/v1.5.0/vanta.pkg"
+# Checksum for v1.5.0; needs to be updated when PKG_URL is updated.
+CHECKSUM="c8bb4d5a499b875149d323337e18ec9ac457322a21f3c161a550e242353d0760"
 PKG_PATH="/tmp/vanta.pkg"
 
 ##

--- a/install-vanta.bat
+++ b/install-vanta.bat
@@ -4,7 +4,7 @@ IF "%~2"=="" goto :needparams
 IF NOT "%~3"=="" goto :needparams
 
 :: download Vanta
-curl -o vanta-installer.exe https://vanta-agent.s3.amazonaws.com/v1.4.1/vanta-installer.exe
+curl -o vanta-installer.exe https://vanta-agent.s3.amazonaws.com/v1.5.0/vanta-installer.exe
 
 :: write config files
 mkdir C:\ProgramData\Vanta


### PR DESCRIPTION
Vanta Agent 1.5.0 is out! The scripts should install it once it's pushed to all of our customers.