### PR TITLE
make windows install script more robust

### DIFF
--- a/install-vanta.bat
+++ b/install-vanta.bat
@@ -1,23 +1,23 @@
+@echo off
 :: check to make sure that both AGENT_KEY and OWNER_EMAIL are specified
 IF "%~1"=="" goto :needparams
 IF "%~2"=="" goto :needparams
 IF NOT "%~3"=="" goto :needparams
 
 :: download Vanta
-curl -o vanta-installer.exe https://vanta-agent.s3.amazonaws.com/v1.4.1/vanta-installer.exe
+curl -o vanta-installer.exe https://vanta-agent.s3.amazonaws.com/v1.5.0/vanta-installer.exe
 
 :: write config files
 mkdir C:\ProgramData\Vanta
-echo {"AGENT_KEY": "%1", "NEEDS_OWNER": true, "OWNER_EMAIL": "%2"} > C:\ProgramData\Vanta\vanta.conf
 
 :: set permissions on config files so installer doesn't overwrite
-icacls C:\ProgramData\Vanta\enroll_secret.txt /grant Everyone:R
-icacls C:\ProgramData\Vanta\vanta.conf /grant Everyone:R
-icacls C:\ProgramData\Vanta\enroll_secret.txt /deny Everyone:W
-icacls C:\ProgramData\Vanta\vanta.conf /deny Everyone:W
+icacls C:\ProgramData\Vanta\vanta.conf /inheritance:r
+icacls C:\ProgramData\Vanta\vanta.conf /grant "everyone":R
 
 :: install vanta
 vanta-installer.exe /S
+echo {"AGENT_KEY": "%1", "NEEDS_OWNER": true, "OWNER_EMAIL": "%2"} > C:\ProgramData\Vanta\vanta.conf
+C:\ProgramData\Vanta\vanta-cli reset
 
 EXIT
 


### PR DESCRIPTION
- No longer attempt to set permissions on enroll_secret.txt, which is no longer shipped with Vanta
- Improve permissions handling on Vanta.conf for cases where ProgramData has unexpected permissions
- vanta-cli reset after writing the config file to force reenrollment once config has been filled in.

Confirmed that installing with this new script installs and enrolls successfully, and that vanta-cli doctor is clean.