### PR TITLE
bump latest to 1.5.7

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -6,11 +6,11 @@
 
 set -e
 
-DEB_URL="https://vanta-agent.s3.amazonaws.com/v1.5.0/vanta.deb"
-RPM_URL="https://vanta-agent.s3.amazonaws.com/v1.5.0/vanta.rpm"
-# Checksums for v1.5.0; need to be updated when PKG_URL is updated.
-DEB_CHECKSUM="44c064961309e9907c4ae5988212d452a873f9a3e75f0c8129ad53ae8f119798"
-RPM_CHECKSUM="fd438f60466fd51d66340f7de8db028c165f2b704c7c766686c6e7b839315f6b"
+DEB_URL="https://vanta-agent.s3.amazonaws.com/v1.5.7/vanta.deb"
+RPM_URL="https://vanta-agent.s3.amazonaws.com/v1.5.7/vanta.rpm"
+# Checksums need to be updated when PKG_URL is updated.
+DEB_CHECKSUM="65e816a169bf401f5ee3cca51997d72f354479db3983f92210e2d827a851dbbe"
+RPM_CHECKSUM="f8f08963f43b689e7dd9e77de8a00c59df0ce4170d8e5b1e19a51f31f509b777"
 DEB_PATH="/tmp/vanta.deb"
 RPM_PATH="/tmp/vanta.rpm"
 DEB_INSTALL_CMD="dpkg -Ei"

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -5,9 +5,9 @@ set -e
 # VANTA_KEY (the Vanta per-domain secret key)
 # VANTA_OWNER_EMAIL (the email of the person who owns this computer. Ignored if VANTA_KEY is missing.)
 
-PKG_URL="https://vanta-agent.s3.amazonaws.com/v1.5.0/vanta.pkg"
-# Checksum for v1.5.0; needs to be updated when PKG_URL is updated.
-CHECKSUM="c8bb4d5a499b875149d323337e18ec9ac457322a21f3c161a550e242353d0760"
+PKG_URL="https://vanta-agent.s3.amazonaws.com/v1.5.7/vanta.pkg"
+# Checksum needs to be updated when PKG_URL is updated.
+CHECKSUM="21fab3741422b5f1b0aa8d41b580b6bb7bd557f1a37fc0117a46496639f7ca87"
 PKG_PATH="/tmp/vanta.pkg"
 
 ##

--- a/install-vanta.bat
+++ b/install-vanta.bat
@@ -1,4 +1,7 @@
 @echo off
+
+echo "This script is deprecated, and is scheduled to be removed. Follow the instructions at https://app.vanta.com/computers instead."
+
 :: check to make sure that both AGENT_KEY and OWNER_EMAIL are specified
 IF "%~1"=="" goto :needparams
 IF "%~2"=="" goto :needparams


### PR DESCRIPTION
Bump the install version to 1.5.7

Note that the batch script is deprecated and is installing an old version of Vanta. Point people to the new one.