### PR TITLE
Ensure that linux hosts are registered before returning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,56 +4,52 @@ on: [push]
 
 jobs:
   build-ubuntu:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Test install on Ubuntu
-      run: |
-        chmod +x ./install-linux.sh
-        VANTA_KEY=FAKEKEY ./install-linux.sh
-    - name: Check that it's running correctly
-      run: vanta-cli status
+      - uses: actions/checkout@v1
+      - name: Test install on Ubuntu
+        run: |
+          chmod +x ./install-linux.sh
+          VANTA_SKIP_REGISTRATION_CHECK=1 VANTA_KEY=FAKEKEY ./install-linux.sh
+      - name: Check that it's running correctly
+        run: vanta-cli status
 
   build-amazonlinux:
-
     runs-on: ubuntu-latest
 
     container: amazonlinux
     steps:
-    - uses: actions/checkout@v1
-    - name: Test install on Ubuntu
-      run: | # system manager issues in docker can be ignored for now
-        chmod +x ./install-linux.sh
-        VANTA_KEY=FAKEKEY ./install-linux.sh
-    - name: Check that the directory exists
-      run: ls /var/vanta
+      - uses: actions/checkout@v1
+      - name: Test install on Ubuntu
+        run: | # system manager issues in docker can be ignored for now
+          chmod +x ./install-linux.sh
+          VANTA_SKIP_REGISTRATION_CHECK=1 VANTA_KEY=FAKEKEY ./install-linux.sh
+      - name: Check that the directory exists
+        run: ls /var/vanta
 
   build-macos:
-
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Test install on macOS
-      run: |
-        chmod +x ./install-macos.sh
-        VANTA_KEY=FAKEKEY ./install-macos.sh
-    - name: Check that it's running correctly
-      run: vanta-cli status
+      - uses: actions/checkout@v1
+      - name: Test install on macOS
+        run: |
+          chmod +x ./install-macos.sh
+          VANTA_KEY=FAKEKEY ./install-macos.sh
+      - name: Check that it's running correctly
+        run: vanta-cli status
 
   build-windows:
-
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Test install on Windows
-      shell: cmd
-      run: |
-        install-vanta.bat fakekey name@example.com
-    - name: Check that the directory exists
-      shell: cmd
-      run: |
-        dir C:\ProgramData\Vanta
+      - uses: actions/checkout@v1
+      - name: Test install on Windows
+        shell: cmd
+        run: |
+          install-vanta.bat fakekey name@example.com
+      - name: Check that the directory exists
+        shell: cmd
+        run: |
+          dir C:\ProgramData\Vanta

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -139,8 +139,8 @@ if [ -z "$VANTA_SKIP_REGISTRATION_CHECK" ] && [ -z "$VANTA_NOSTART" ]; then
     if [ "$registration_success" = false ] ; then
         printf "\033[31m
     Could not verify that the agent is registered to a Vanta domain. Are you sure you used the right key?
-    \n\033[0m\n"
-        exit 1
+    \n\033[0m\n" >&2
+        exit 0
     fi
 
 else

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -134,6 +134,22 @@ do
     sleep 3
 done
 
+##
+# Check whether the agent is registered. It may take a couple of seconds,
+# so try 3 times with 3-second pauses in between.
+##
+printf "\033[34m\n* Checking registration with Vanta\n\033[0m"
+registration_success=false
+for i in {1..3}
+do
+    echo "Attempt $i/3"
+    if $SUDO /var/vanta/vanta-cli check-registration; then
+        registration_success=true
+        break
+    fi
+    sleep 3
+done
+
 if [ "$registration_success" = false ] ; then
     printf "\033[31m
 Could not verify that the agent is registered to a Vanta domain. Are you sure you used the right key?

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -123,25 +123,29 @@ $SUDO $INSTALL_CMD $PKG_PATH
 # Check whether the agent is registered. It may take a couple of seconds,
 # so try 3 times with 3-second pauses in between.
 ##
-printf "\033[34m\n* Checking registration with Vanta\n\033[0m"
-registration_success=false
-for i in {1..3}
-do
-    echo "Attempt $i/3"
-    if $SUDO /var/vanta/vanta-cli check-registration; then
-        registration_success=true
-        break
+if [ -z "$VANTA_SKIP_REGISTRATION_CHECK" ]; then
+    printf "\033[34m\n* Checking registration with Vanta\n\033[0m"
+    registration_success=false
+    for i in {1..3}
+    do
+        echo "Attempt $i/3"
+        if $SUDO /var/vanta/vanta-cli check-registration; then
+            registration_success=true
+            break
+        fi
+        sleep 3
+    done
+
+    if [ "$registration_success" = false ] ; then
+        printf "\033[31m
+    Could not verify that the agent is registered to a Vanta domain. Are you sure you used the right key?
+    \n\033[0m\n"
+        exit 1
     fi
-    sleep 3
-done
 
-if [ "$registration_success" = false ] ; then
-    printf "\033[31m
-Could not verify that the agent is registered to a Vanta domain. Are you sure you used the right key?
-\n\033[0m\n"
-    exit 1
+else
+    printf "\033[34m\n* Skipping registration check\n\033[0m"
 fi
-
 
 printf "\033[32m
 The Vanta agent has been installed successfully.

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -120,21 +120,6 @@ printf "\033[34m\n* Installing the Vanta Agent. You might be asked for your pass
 $SUDO $INSTALL_CMD $PKG_PATH
 
 ##
-# Check whether the agent is registered. It may take a couple of seconds, so try 3 times with 3-second
-# pauses in between.
-##
-printf "\033[34m\n* Checking registration with Vanta\n\033[0m"
-registration_success=false
-for _ in {1..3}
-do
-    if /var/vanta/vanta-cli check-registration; then
-        registration_success=true
-        break
-    fi
-    sleep 3
-done
-
-##
 # Check whether the agent is registered. It may take a couple of seconds,
 # so try 3 times with 3-second pauses in between.
 ##

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -123,7 +123,7 @@ $SUDO $INSTALL_CMD $PKG_PATH
 # Check whether the agent is registered. It may take a couple of seconds,
 # so try 3 times with 3-second pauses in between.
 ##
-if [ -z "$VANTA_SKIP_REGISTRATION_CHECK" ] || [ -z "$VANTA_NOSTART" ]; then
+if [ -z "$VANTA_SKIP_REGISTRATION_CHECK" ] && [ -z "$VANTA_NOSTART" ]; then
     printf "\033[34m\n* Checking registration with Vanta\n\033[0m"
     registration_success=false
     for i in {1..3}

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -119,6 +119,29 @@ fi
 printf "\033[34m\n* Installing the Vanta Agent. You might be asked for your password...\n\033[0m"
 $SUDO $INSTALL_CMD $PKG_PATH
 
+##
+# Check whether the agent is registered. It may take a couple of seconds, so try 3 times with 3-second
+# pauses in between.
+##
+printf "\033[34m\n* Checking registration with Vanta\n\033[0m"
+registration_success=false
+for _ in {1..3}
+do
+    if /var/vanta/vanta-cli check-registration; then
+        registration_success=true
+        break
+    fi
+    sleep 3
+done
+
+if [ "$registration_success" = false ] ; then
+    printf "\033[31m
+Could not verify that the agent is registered to a Vanta domain. Are you sure you used the right key?
+\n\033[0m\n"
+    exit 1
+fi
+
+
 printf "\033[32m
 The Vanta agent has been installed successfully.
 It will continue to run in the background and submit data to Vanta.

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -123,7 +123,7 @@ $SUDO $INSTALL_CMD $PKG_PATH
 # Check whether the agent is registered. It may take a couple of seconds,
 # so try 3 times with 3-second pauses in between.
 ##
-if [ -z "$VANTA_SKIP_REGISTRATION_CHECK" ]; then
+if [ -z "$VANTA_SKIP_REGISTRATION_CHECK" ] || [ -z "$VANTA_NOSTART" ]; then
     printf "\033[34m\n* Checking registration with Vanta\n\033[0m"
     registration_success=false
     for i in {1..3}
@@ -149,7 +149,7 @@ fi
 
 printf "\033[32m
 The Vanta agent has been installed successfully.
-It will continue to run in the background and submit data to Vanta.
+It will run in the background and submit data to Vanta.
 
 You can check the agent status using the \"vanta-cli status\" command.
 \033[0m"


### PR DESCRIPTION
Fail install if the host is not registered to Vanta. 

Check runs 3 times with 3-second pauses in between, in case registration took a long time or Vanta returns an error code.

Check is skipped in CI or if VANTA_NOSTART is true. 