### PR TITLE
Increase chances of registration checks working

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -121,19 +121,21 @@ $SUDO $INSTALL_CMD $PKG_PATH
 
 ##
 # Check whether the agent is registered. It may take a couple of seconds,
-# so try 3 times with 3-second pauses in between.
+# so try 5 times with 5-second pauses in between.
 ##
 if [ -z "$VANTA_SKIP_REGISTRATION_CHECK" ] && [ -z "$VANTA_NOSTART" ]; then
     printf "\033[34m\n* Checking registration with Vanta\n\033[0m"
     registration_success=false
-    for i in {1..3}
+    # It always fails on the first attempt so we might as well pause here.
+    sleep 5
+    for i in {1..5}
     do
-        echo "Attempt $i/3"
+        echo "Attempt $i/5"
         if $SUDO /var/vanta/vanta-cli check-registration; then
             registration_success=true
             break
         fi
-        sleep 3
+        sleep 5
     done
 
     if [ "$registration_success" = false ] ; then

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -126,16 +126,15 @@ $SUDO $INSTALL_CMD $PKG_PATH
 if [ -z "$VANTA_SKIP_REGISTRATION_CHECK" ] && [ -z "$VANTA_NOSTART" ]; then
     printf "\033[34m\n* Checking registration with Vanta\n\033[0m"
     registration_success=false
-    # It always fails on the first attempt so we might as well pause here.
-    sleep 5
     for i in {1..5}
     do
+        # Pause first, as the chances of registration working immediately are low.
+        sleep 5
         echo "Attempt $i/5"
         if $SUDO /var/vanta/vanta-cli check-registration; then
             registration_success=true
             break
         fi
-        sleep 5
     done
 
     if [ "$registration_success" = false ] ; then


### PR DESCRIPTION
Right now this script regularly fails for me during the registration step, however it seems that this is just because registration is taking longer than expected. When I pause and run the check-registration command myself it works.

What I've done here is-

* Add a five second pause before the very first check.
* Increased the sleep period from three to five seconds.
* Increased the number of checks from three to five.

This changes the total waiting period from a maximum of six seconds to 25 seconds, which seems to be more than enough time.

One change I did *not* make, because it would break backwards compatibility, is to change the exist code to fail when the registration doesn't work. I think this should be done at some point- we're running this script as part of a build process and I think if the agent can't register to Vanta then the build should fail.