### PR TITLE
linux: fast exit without errors when distro is not supported

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -46,6 +46,18 @@ else
     SUDO='sudo -E'
 fi
 
+if ! command -v lsb_release &> /dev/null; then
+    NO_LSB=true
+fi
+
+function get_distribution() {
+    if [ -n "${NO_LSB}" ]; then
+        echo "${DISTRIBUTION}"
+    else
+	lsb_release -s
+    fi
+}
+
 if [ "${OS}" == "Debian" ]; then
     printf "\033[34m\n* Debian detected \n\033[0m"
     PKG_URL=$DEB_URL
@@ -60,7 +72,7 @@ elif [ "${OS}" == "RedHat" ]; then
     CHECKSUM=$RPM_CHECKSUM
 else
     printf "\033[31m
-Cannot install the Vanta agent on unsupported platform $(lsb_release -sd).
+Cannot install the Vanta agent on unsupported platform $(get_platform).
 Please reach out to support@vanta.com for help.
 \n\033[0m\n"
     exit 1

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -40,7 +40,7 @@ fi
 ##
 # Vanta needs to be installed as root; use sudo if not already uid 0
 ##
-if [ "$(echo "$UID")" = "0" ]; then
+if [ $(echo "$UID") = "0" ]; then
     SUDO=''
 else
     SUDO='sudo -E'

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -46,11 +46,11 @@ else
     SUDO='sudo -E'
 fi
 
-if ! command -v lsb_release &> /dev/null; then
-    NO_LSB=true
-fi
-
 function get_platform() {
+    if ! command -v lsb_release &> /dev/null; then
+        NO_LSB=true
+    fi
+
     if [ -n "${NO_LSB}" ]; then
         echo "${DISTRIBUTION}"
     else

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -48,10 +48,6 @@ fi
 
 function get_platform() {
     if ! command -v lsb_release &> /dev/null; then
-        NO_LSB=true
-    fi
-
-    if [ -n "${NO_LSB}" ]; then
         echo "${DISTRIBUTION}"
     else
 	lsb_release -sd

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -37,27 +37,22 @@ elif [ -f /etc/SuSE-release -o "$DISTRIBUTION" == "SUSE" -o "$DISTRIBUTION" == "
     OS="SUSE"
 fi
 
-[ -z "${OS}" ] && {
-    echo "$(lsb_release -sd) is not a supported operating system"
-    exit 1
-}
-
 ##
 # Vanta needs to be installed as root; use sudo if not already uid 0
 ##
-if [ $(echo "$UID") = "0" ]; then
+if [ "$(echo "$UID")" = "0" ]; then
     SUDO=''
 else
     SUDO='sudo -E'
 fi
 
-if [ $OS == "Debian" ]; then
+if [ "${OS}" == "Debian" ]; then
     printf "\033[34m\n* Debian detected \n\033[0m"
     PKG_URL=$DEB_URL
     PKG_PATH=$DEB_PATH
     INSTALL_CMD=$DEB_INSTALL_CMD
     CHECKSUM=$DEB_CHECKSUM
-elif [ $OS == "RedHat" ]; then
+elif [ "${OS}" == "RedHat" ]; then
     printf "\033[34m\n* RedHat detected \n\033[0m"
     PKG_URL=$RPM_URL
     PKG_PATH=$RPM_PATH
@@ -83,6 +78,8 @@ Something went wrong while installing the Vanta agent.
 
 If you're having trouble installing, please send an email to support@vanta.com, and we'll help you fix it!
 \n\033[0m\n"
+
+    exit 1
 }
 trap onerror ERR
 

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -54,7 +54,7 @@ function get_platform() {
     if [ -n "${NO_LSB}" ]; then
         echo "${DISTRIBUTION}"
     else
-	lsb_release -s
+	lsb_release -sd
     fi
 }
 

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -50,7 +50,7 @@ if ! command -v lsb_release &> /dev/null; then
     NO_LSB=true
 fi
 
-function get_distribution() {
+function get_platform() {
     if [ -n "${NO_LSB}" ]; then
         echo "${DISTRIBUTION}"
     else

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -63,6 +63,7 @@ else
 Cannot install the Vanta agent on unsupported platform $(lsb_release -sd).
 Please reach out to support@vanta.com for help.
 \n\033[0m\n"
+    exit 1
 fi
 
 if [ -z "$VANTA_KEY" ]; then
@@ -78,8 +79,6 @@ Something went wrong while installing the Vanta agent.
 
 If you're having trouble installing, please send an email to support@vanta.com, and we'll help you fix it!
 \n\033[0m\n"
-
-    exit 1
 }
 trap onerror ERR
 

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -60,7 +60,7 @@ elif [ "${OS}" == "RedHat" ]; then
     CHECKSUM=$RPM_CHECKSUM
 else
     printf "\033[31m
-Cannot install the Vanta agent on unsupported platform $DISTRIBUTION.
+Cannot install the Vanta agent on unsupported platform $(lsb_release -sd).
 Please reach out to support@vanta.com for help.
 \n\033[0m\n"
 fi

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -37,6 +37,11 @@ elif [ -f /etc/SuSE-release -o "$DISTRIBUTION" == "SUSE" -o "$DISTRIBUTION" == "
     OS="SUSE"
 fi
 
+[ -z "${OS}" ] && {
+    echo "$(lsb_release -sd) is not a supported operating system"
+    exit 1
+}
+
 ##
 # Vanta needs to be installed as root; use sudo if not already uid 0
 ##


### PR DESCRIPTION
A user reported an issue running this script on a Linux distribution that's derived from Arch Linux called Manjaro. The script is not expected to succeed in this case, but this pull request ensures it prints a short and actionable error to the user.

Before this change the script runs into errors when its run on an unsupported distribution:

```
bash -c "$(curl -L https://raw.githubusercontent.com/VantaInc/vanta-agent-scripts/master/install-linux.sh)"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5126  100  5126    0     0  16273      0 --:--:-- --:--:-- --:--:-- 16273
bash: line 48: [: ==: unary operator expected
bash: line 54: [: ==: unary operator expected
Cannot install the Vanta agent on unsupported platform Linux.
Please reach out to support@vanta.com for help.
* Downloading the Vanta Agent
bash: line 88: $PKG_PATH: ambiguous redirect
Something went wrong while installing the Vanta agent.
If you're having trouble installing, please send an email to support@vanta.com, and we'll help you fix it!
```

After this change:

```
Cannot install the Vanta agent on unsupported platform "Manjaro Linux".
Please reach out to support@vanta.com for help.
```