### PR TITLE
Include instructions for installing Rosetta on Apple Silicon

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -26,6 +26,14 @@ You must specify the VANTA_KEY environment variable in order to install the agen
     exit 1
 fi
 
+if [ $(/usr/bin/arch) == "arm64" ] && [ ! -f "/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist" ]; then
+    printf "\033[31m
+You must set up Rosetta on your Mac in order to install the agent. Please
+follow the setup instructions from Apple here: https://support.apple.com/en-us/HT211861.
+\n\033[0m\n"
+    exit 1
+fi
+
 function onerror() {
     printf "\033[31m$ERROR_MESSAGE
 Something went wrong while installing the Vanta agent.


### PR DESCRIPTION
With this change, if a user tries to run the install-macos script on an ARM Mac without Rosetta, the script will error out and direct them to the help pages for configuring their Mac. Rosetta is a requirement of the agent (I believe because it uses Go).

Tested locally on an Apple Silicon MacBook Pro.