### PR TITLE
update agent version to 2.0.0

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -7,8 +7,8 @@
 
 set -e
 
-DEB_URL="https://vanta-agent.s3.amazonaws.com/v1.8.5/vanta.deb"
-RPM_URL="https://vanta-agent.s3.amazonaws.com/v1.8.5/vanta.rpm"
+DEB_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.0.0/vanta-amd64.deb"
+RPM_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.0.0/vanta-amd64.rpm"
 # Checksums need to be updated when PKG_URL is updated.
 DEB_CHECKSUM="342956d99825beb3625807979fb815633b1d8c0e4e26b0acb43f4aa29672b1b2"
 RPM_CHECKSUM="ce6ed4b2a3671031b02d8b31dcdde87442d4a90b47f6bd279924a3db7f4d3020"

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -10,8 +10,8 @@ set -e
 DEB_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.0.0/vanta-amd64.deb"
 RPM_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.0.0/vanta-amd64.rpm"
 # Checksums need to be updated when PKG_URL is updated.
-DEB_CHECKSUM="342956d99825beb3625807979fb815633b1d8c0e4e26b0acb43f4aa29672b1b2"
-RPM_CHECKSUM="ce6ed4b2a3671031b02d8b31dcdde87442d4a90b47f6bd279924a3db7f4d3020"
+DEB_CHECKSUM="54e9043e0ee2bb454b85ccb9e6eb2ef2b839b24545d99f524700757d918ea508"
+RPM_CHECKSUM="7539237b1275966ddb741739853f108f28603e909f09f3baccb1383fbc904522"
 DEB_PATH="/tmp/vanta.deb"
 RPM_PATH="/tmp/vanta.rpm"
 DEB_INSTALL_CMD="dpkg -Ei"

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -5,9 +5,9 @@ set -e
 # VANTA_KEY (the Vanta per-domain secret key)
 # VANTA_OWNER_EMAIL (the email of the person who owns this computer. Ignored if VANTA_KEY is missing.)
 
-PKG_URL="https://vanta-agent.s3.amazonaws.com/v1.8.5/vanta.pkg"
+PKG_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.0.0/vanta-universal.pkg"
 # Checksum needs to be updated when PKG_URL is updated.
-CHECKSUM="e602076c26805d9b146b2a9d41accca1ed144890ec21ac650c9bb65d911b1dd3"
+CHECKSUM="93042c2421767323557f1fa600fd971aebe1c402bd75609a18e215608ae47b2c"
 PKG_PATH="/tmp/vanta.pkg"
 
 ##


### PR DESCRIPTION
- Update the default install version to 2.0.0
- Fetch the packages from our tuf repo instead of the notary mirror
- Specify architecture (this script still only supports x86, but will be updated to support arm shortly)