### PR TITLE
Remove Rosetta check from macOS install script

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -26,14 +26,6 @@ You must specify the VANTA_KEY environment variable in order to install the agen
     exit 1
 fi
 
-if [ $(/usr/bin/arch) == "arm64" ] && [ ! -f "/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist" ]; then
-    printf "\033[31m
-You must set up Rosetta on your Mac in order to install the agent. Please
-follow the setup instructions from Apple here: https://support.apple.com/en-us/HT211861.
-\n\033[0m\n"
-    exit 1
-fi
-
 function onerror() {
     printf "\033[31m$ERROR_MESSAGE
 Something went wrong while installing the Vanta agent.


### PR DESCRIPTION
As of agent version 1.8.5, the agent is a universal binary, so Rosetta is no longer needed. Additionally, from experience earlier today, the Rosetta plist may no longer be where this script expects it to be, due to successive revisions to Rosetta itself, so the script might fail even if Rosetta is installed.