### PR TITLE
add updated rosetta check

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -26,10 +26,13 @@ You must specify the VANTA_KEY environment variable in order to install the agen
     exit 1
 fi
 
-if [ $(/usr/bin/arch) == "arm64" ] && [ ! -f "/Library/Apple/System/Library/LaunchDaemons/com.apple.oahd.plist" ]; then
+
+if [ $(/usr/bin/arch) == "arm64" ] && ! /usr/bin/pgrep oahd >/dev/null 2>&1; then
     printf "\033[31m
 You must set up Rosetta on your Mac in order to install the agent. Please
 follow the setup instructions from Apple here: https://support.apple.com/en-us/HT211861.
+To install Rosetta, run
+    /usr/sbin/softwareupdate --install-rosetta
 \n\033[0m\n"
     exit 1
 fi

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -29,8 +29,8 @@ fi
 
 if [ $(/usr/bin/arch) == "arm64" ] && ! /usr/bin/pgrep oahd >/dev/null 2>&1; then
     printf "\033[31m
-You must set up Rosetta on your Mac in order to install the agent. Please
-follow the setup instructions from Apple here: https://support.apple.com/en-us/HT211861.
+You must set up Rosetta on your Mac in order to install the agent. You can find information
+about Rosetta here: https://support.apple.com/en-us/HT211861.
 To install Rosetta, run
     /usr/sbin/softwareupdate --install-rosetta
 \n\033[0m\n"


### PR DESCRIPTION
#46 found that the Rosetta check wasn't working for new versions of OS X. Taking inspiration from https://community.jamf.com/t5/jamf-pro/how-to-check-if-rosetta2-is-installed-macos-11-5/td-p/242562, update our install script to check for the presence of the oahd process as opposed to a plist file that no longer exists.

[sc37620]