### PR TITLE
Show path to vanta-cli in post-install message on linux.

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -231,5 +231,5 @@ printf "\033[32m
 The Vanta agent has been installed successfully.
 It will run in the background and submit data to Vanta.
 
-You can check the agent status using the \"vanta-cli status\" command.
+You can check the agent status using the \"/var/vanta/vanta-cli status\" command.
 \033[0m"


### PR DESCRIPTION
Ideally, `vanta-cli` should be installed into `/usr/local/bin` or `/usr/bin` so that we could just run `vanta-cli` without knowing its path. This PR just prints the full path so that the user doesn't have to worry that the install went wrong.