### PR TITLE
Add Developer ID and Cert Fingerprint Validation

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -8,6 +8,8 @@ set -e
 PKG_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.0.8/vanta-universal.pkg"
 # Checksum needs to be updated when PKG_URL is updated.
 CHECKSUM="7e60f3a6f4057ec40ba26c8670068a4d7f82847575511d0393287c1fc899522e"
+DEVELOPER_ID="Vanta Inc (632L25QNV4)"
+CERT_SHA_FINGERPRINT="D90D17FA20360BC635BC1A59B9FA5C6F9C9C2D4915711E4E0C182AA11E772BEF"
 PKG_PATH="$(mktemp -d)/vanta.pkg"
 
 ##
@@ -65,6 +67,29 @@ if [ $downloaded_checksum = $CHECKSUM ]; then
     printf "\033[34mChecksums match.\n\033[0m"
 else
     printf "\033[31m Checksums do not match. Please contact support@vanta.com \033[0m\n"
+    exit 1
+fi
+
+##
+# Check Developer ID
+##
+printf "\033[34m\n* Ensuring package Developer ID matches\n\033[0m"
+
+if pkgutil --check-signature $PKG_PATH | grep -q "$DEVELOPER_ID"; then
+    printf "\033[34mDeveloper ID matches.\n\033[0m"
+else
+    printf "\033[31m Developer ID does not match. Please contact support@vanta.com \033[0m\n"
+    exit 1
+fi
+
+##
+# Check Developer Certificate Fingerprint
+##
+printf "\033[34m\n* Ensuring package Developer Certificate Fingerprint matches\n\033[0m"
+if pkgutil --check-signature $PKG_PATH | tr -d '\n' | tr -d ' ' | grep -q "SHA256Fingerprint:$CERT_SHA_FINGERPRINT"; then
+    printf "\033[34mDeveloper Certificate Fingerprint matches.\n\033[0m"
+else
+    printf "\033[31m Developer Certificate Fingerprint does not match. Please contact support@vanta.com \033[0m\n"
     exit 1
 fi
 

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -75,7 +75,7 @@ fi
 ##
 printf "\033[34m\n* Ensuring package Developer ID matches\n\033[0m"
 
-if pkgutil --check-signature $PKG_PATH | grep -q "$DEVELOPER_ID"; then
+if pkgutil --check-signature $PKG_PATH | /usr/bin/grep -q "$DEVELOPER_ID"; then
     printf "\033[34mDeveloper ID matches.\n\033[0m"
 else
     printf "\033[31m Developer ID does not match. Please contact support@vanta.com \033[0m\n"
@@ -86,7 +86,7 @@ fi
 # Check Developer Certificate Fingerprint
 ##
 printf "\033[34m\n* Ensuring package Developer Certificate Fingerprint matches\n\033[0m"
-if pkgutil --check-signature $PKG_PATH | tr -d '\n' | tr -d ' ' | grep -q "SHA256Fingerprint:$CERT_SHA_FINGERPRINT"; then
+if pkgutil --check-signature $PKG_PATH | /usr/bin/tr -d '\n' | /usr/bin/tr -d ' ' | /usr/bin/grep -q "SHA256Fingerprint:$CERT_SHA_FINGERPRINT"; then
     printf "\033[34mDeveloper Certificate Fingerprint matches.\n\033[0m"
 else
     printf "\033[31m Developer Certificate Fingerprint does not match. Please contact support@vanta.com \033[0m\n"


### PR DESCRIPTION
This adds signature verification that the package pulled down matches the intended author, Vanta.

Apple suggests checking fingerprints as a way of verifying a package: https://support.apple.com/en-us/HT202369
Jamf also posted an article about reverse engineering pkgutil to extend a more direct verification which I think is out of scope for this script: https://www.jamf.com/blog/reversing-pkgutil-to-verify-pkgs/

Developer ID & SHA Fingerprint can be obtained from `pkgutil`:

```
➜ pkgutil -v --check-signature vanta-universal-2.0.8.pkg
Package "vanta-universal-2.0.8.pkg":
   Status: signed by a developer certificate issued by Apple for distribution
   Notarization: trusted by the Apple notary service
   Signed with a trusted timestamp on: 2022-01-04 21:32:44 +0000
   Certificate Chain:
    1. Developer ID Installer: Vanta Inc (632L25QNV4)
       Expires: 2025-03-10 16:29:55 +0000
       SHA256 Fingerprint:
           D9 0D 17 FA 20 36 0B C6 35 BC 1A 59 B9 FA 5C 6F 9C 9C 2D 49 15 71
           1E 4E 0C 18 2A A1 1E 77 2B EF
       ------------------------------------------------------------------------
    2. Developer ID Certification Authority
       Expires: 2027-02-01 22:12:15 +0000
       SHA256 Fingerprint:
           7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
           F2 9C 88 CF B0 B1 BA 63 58 7F
       ------------------------------------------------------------------------
    3. Apple Root CA
       Expires: 2035-02-09 21:40:36 +0000
       SHA256 Fingerprint:
           B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
           68 C5 BE 91 B5 A1 10 01 F0 24
```

It can also be verified in the GUI (padlock top right):

<img width="620" alt="image" src="https://user-images.githubusercontent.com/31187/152463417-bc8bc943-aa5d-4b1e-ae73-16066b31c813.png">


This remains constant with previous releases:

```
➜ pkgutil -v --check-signature vanta-universal-2.0.7.pkg
Package "vanta-universal-2.0.7.pkg":
   Status: signed by a developer certificate issued by Apple for distribution
   Notarization: trusted by the Apple notary service
   Signed with a trusted timestamp on: 2021-12-18 00:53:02 +0000
   Certificate Chain:
    1. Developer ID Installer: Vanta Inc (632L25QNV4)
       Expires: 2025-03-10 16:29:55 +0000
       SHA256 Fingerprint:
           D9 0D 17 FA 20 36 0B C6 35 BC 1A 59 B9 FA 5C 6F 9C 9C 2D 49 15 71
           1E 4E 0C 18 2A A1 1E 77 2B EF
       ------------------------------------------------------------------------
    2. Developer ID Certification Authority
       Expires: 2027-02-01 22:12:15 +0000
       SHA256 Fingerprint:
           7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
           F2 9C 88 CF B0 B1 BA 63 58 7F
       ------------------------------------------------------------------------
    3. Apple Root CA
       Expires: 2035-02-09 21:40:36 +0000
       SHA256 Fingerprint:
           B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
           68 C5 BE 91 B5 A1 10 01 F0 24

```
Note the different signature date.

Checksums for reference:
```
➜ shasum -a256 vanta-universal-2.0.7.pkg
3bf59fb1c75880d7b744309a89f233d2c0e7e616cf4e328bf75c7fb3ad6aa56a  vanta-universal-2.0.7.pkg


➜ shasum -a256 vanta-universal-2.0.8.pkg
7e60f3a6f4057ec40ba26c8670068a4d7f82847575511d0393287c1fc899522e  vanta-universal-2.0.8.pkg
```

**Output during install with successful match:**
```
➜ VANTA_KEY='test' ./install-macos.sh

* Downloading the Vanta Agent
############################################################################################# 100.0%

* Ensuring checksums match
Checksums match.

* Ensuring package Developer ID matches
Developer ID matches.

* Ensuring package Developer Certificate Fingerprint matches
Developer Certificate Fingerprint matches.

* Installing the Vanta Agent. You might be asked for your password...
Password:
...
```

**Output during fingerprint mismatch:**
```
➜ VANTA_KEY='test' ./install-macos.sh

* Downloading the Vanta Agent
############################################################################################# 100.0%

* Ensuring checksums match
Checksums match.

* Ensuring package Developer ID matches
Developer ID matches.

* Ensuring package Developer Certificate Fingerprint matches
 Developer Certificate Fingerprint does not match. Please contact support@vanta.com
```


**Output during Developer ID mismatch:**
```
➜ VANTA_KEY='test' ./install-macos.sh

* Downloading the Vanta Agent
############################################################################################# 100.0%

* Ensuring checksums match
Checksums match.

* Ensuring package Developer ID matches
 Developer ID does not match. Please contact support@vanta.com
```
 