### PR TITLE
Add pull-request trigger for automated checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
   pull_request:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   build-ubuntu:


### PR DESCRIPTION
We previously ran actions on push from trusted users and on demand using workflow_dispatch, but there is no easy way to run them against untrusted pull requests by default.

Luckily, github supports this – actions triggered by pull_request are executed in a read-only secret-less sandbox. 

See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

We need this to run CI against incoming PRs without taking over the branches.