### PR TITLE
Remove Rosetta requirement for arm64

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -29,16 +29,6 @@ You must specify the VANTA_KEY environment variable in order to install the agen
 fi
 
 
-if [ $(/usr/bin/arch) == "arm64" ] && ! /usr/bin/pgrep oahd >/dev/null 2>&1; then
-    printf "\033[31m
-You must set up Rosetta on your Mac in order to install the agent. You can find information
-about Rosetta here: https://support.apple.com/en-us/HT211861.
-To install Rosetta, run
-    /usr/sbin/softwareupdate --install-rosetta
-\n\033[0m\n"
-    exit 1
-fi
-
 function onerror() {
     printf "\033[31m$ERROR_MESSAGE
 Something went wrong while installing the Vanta agent.


### PR DESCRIPTION
The current 2.2.2 binary installs and works on MacOS MX (arm64) without Rosetta with no issues. There is no need to install Rosetta so this check is unnecessary. I'm guessing this was an artifact from earlier builds.

/cc @favila