### PR TITLE
Various fixes to Vanta install script

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -26,27 +26,27 @@ UUID_PATH="/sys/class/dmi/id/product_uuid"
 # Try lsb_release, fallback with /etc/issue then uname command
 # Detection code taken from https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/install_script.sh
 KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE)"
-DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || grep -m1 -Eo $KNOWN_DISTRIBUTION /etc/os-release 2>/dev/null || uname -s)
+DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo "$KNOWN_DISTRIBUTION"  || grep -Eo "$KNOWN_DISTRIBUTION" /etc/issue 2>/dev/null || grep -Eo "$KNOWN_DISTRIBUTION" /etc/Eos-release 2>/dev/null || grep -m1 -Eo "$KNOWN_DISTRIBUTION" /etc/os-release 2>/dev/null || uname -s)
 
-if [ -f /etc/debian_version -o "$DISTRIBUTION" == "Debian" -o "$DISTRIBUTION" == "Ubuntu" ]; then
+if [ -f /etc/debian_version ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
     OS="Debian"
-elif [ -f /etc/redhat-release -o "$DISTRIBUTION" == "RedHat" -o "$DISTRIBUTION" == "CentOS" -o "$DISTRIBUTION" == "Amazon" ]; then
+elif [ -f /etc/redhat-release ] || [ "$DISTRIBUTION" == "RedHat" ] || [ "$DISTRIBUTION" == "CentOS" ] || [ "$DISTRIBUTION" == "Amazon" ]; then
     OS="RedHat"
 # Some newer distros like Amazon may not have a redhat-release file
-elif [ -f /etc/system-release -o "$DISTRIBUTION" == "Amazon" ]; then
+elif [ -f /etc/system-release ] || [ "$DISTRIBUTION" == "Amazon" ]; then
     OS="RedHat"
 # Arista is based off of Fedora14/18 but do not have /etc/redhat-release
-elif [ -f /etc/Eos-release -o "$DISTRIBUTION" == "Arista" ]; then
+elif [ -f /etc/Eos-release ] || [ "$DISTRIBUTION" == "Arista" ]; then
     OS="RedHat"
 # openSUSE and SUSE use /etc/SuSE-release or /etc/os-release
-elif [ -f /etc/SuSE-release -o "$DISTRIBUTION" == "SUSE" -o "$DISTRIBUTION" == "openSUSE" ]; then
+elif [ -f /etc/SuSE-release ] || [ "$DISTRIBUTION" == "SUSE" ] || [ "$DISTRIBUTION" == "openSUSE" ]; then
     OS="SUSE"
 fi
 
 ##
 # Vanta needs to be installed as root; use sudo if not already uid 0
 ##
-if [ $(echo "$UID") = "0" ]; then
+if [ "$(echo "$UID")" = "0" ]; then
     SUDO=''
 else
     SUDO='sudo -E'
@@ -140,8 +140,8 @@ if [ ! -z "$VANTA_EXPERIMENTAL_SELINUX" ]; then
     fi
 
     printf "\033[34m\n* Downloading the SELinux package\n\033[0m"
-    rm -f $SELINUX_PATH
-    curl --progress-bar --output $SELINUX_PATH $SELINUX_URL
+    rm -f "$SELINUX_PATH"
+    curl --progress-bar --output "$SELINUX_PATH" "$SELINUX_URL"
 fi
 
 function onerror() {
@@ -157,8 +157,8 @@ trap onerror ERR
 # Download the agent
 ##
 printf "\033[34m\n* Downloading the Vanta Agent\n\033[0m"
-rm -f $PKG_PATH
-curl --progress-bar --output $PKG_PATH $PKG_URL
+rm -f "$PKG_PATH"
+curl --progress-bar --output "$PKG_PATH" "$PKG_URL"
 
 ##
 # Checksum
@@ -166,9 +166,9 @@ curl --progress-bar --output $PKG_PATH $PKG_URL
 printf "\033[34m\n* Ensuring checksums match\n\033[0m"
 
 if [ -x "$(command -v shasum)" ]; then
-  downloaded_checksum=$(shasum -a256 $PKG_PATH | cut -d" " -f1)
+  downloaded_checksum=$(shasum -a256 "$PKG_PATH" | cut -d" " -f1)
 elif [ -x "$(command -v sha256sum)" ]; then
-  downloaded_checksum=$(sha256sum $PKG_PATH | cut -d" " -f1)
+  downloaded_checksum=$(sha256sum "$PKG_PATH" | cut -d" " -f1)
 else
   printf "\033[31m shasum is not installed. Not checking binary contents. \033[0m\n"
   # For now, don't fail if shasum is not installed. Delete this check if you want to
@@ -176,7 +176,7 @@ else
   CHECKSUM=""
 fi
 
-if [ $downloaded_checksum = $CHECKSUM ]; then
+if [ "$downloaded_checksum" = "$CHECKSUM" ]; then
     printf "\033[34mChecksums match.\n\033[0m"
 else
     printf "\033[31m Checksums do not match. Please contact support@vanta.com \033[0m\n"
@@ -187,16 +187,15 @@ fi
 # Install the agent
 ##
 printf "\033[34m\n* Installing the Vanta Agent. You might be asked for your password...\n\033[0m"
-$SUDO $INSTALL_CMD $PKG_PATH
+$SUDO $INSTALL_CMD "$PKG_PATH"
 
 ##
 # Install the SELinux package
 ##
-if [ ! -z "$VANTA_EXPERIMENTAL_SELINUX" ]; then
+if [ -n "$VANTA_EXPERIMENTAL_SELINUX" ]; then
     printf "\033[34m\n* Installing SELinux support\n\033[0m"
-    $SUDO $INSTALL_CMD $SELINUX_PATH
+     $SUDO $INSTALL_CMD "$SELINUX_PATH"
 fi
-
 
 ##
 # Check whether the agent is registered. It may take a couple of seconds,

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -15,7 +15,7 @@ PKG_PATH="$(mktemp -d)/vanta.pkg"
 ##
 # Vanta needs to be installed as root; use sudo if not already uid 0
 ##
-if [ $(echo "$UID") = "0" ]; then
+if [ "$(echo "$UID")" = "0" ]; then
     SUDO=''
 else
     SUDO='sudo -E'
@@ -43,15 +43,15 @@ trap onerror ERR
 # Download the agent
 ##
 printf "\033[34m\n* Downloading the Vanta Agent\n\033[0m"
-rm -f $PKG_PATH
-curl --progress-bar $PKG_URL >$PKG_PATH
+rm -f "$PKG_PATH"
+curl --progress-bar "$PKG_URL" >"$PKG_PATH"
 
 ##
 # Checksum
 ##
 printf "\033[34m\n* Ensuring checksums match\n\033[0m"
-downloaded_checksum=$(shasum -a256 $PKG_PATH | cut -d" " -f1)
-if [ $downloaded_checksum = $CHECKSUM ]; then
+downloaded_checksum="$(shasum -a256 "$PKG_PATH" | cut -d" " -f1)"
+if [ "$downloaded_checksum" = "$CHECKSUM" ]; then
     printf "\033[34mChecksums match.\n\033[0m"
 else
     printf "\033[31m Checksums do not match. Please contact support@vanta.com \033[0m\n"
@@ -63,7 +63,7 @@ fi
 ##
 printf "\033[34m\n* Ensuring package Developer ID matches\n\033[0m"
 
-if pkgutil --check-signature $PKG_PATH | /usr/bin/grep -q "$DEVELOPER_ID"; then
+if pkgutil --check-signature "$PKG_PATH" | /usr/bin/grep -q "$DEVELOPER_ID"; then
     printf "\033[34mDeveloper ID matches.\n\033[0m"
 else
     printf "\033[31m Developer ID does not match. Please contact support@vanta.com \033[0m\n"
@@ -74,7 +74,7 @@ fi
 # Check Developer Certificate Fingerprint
 ##
 printf "\033[34m\n* Ensuring package Developer Certificate Fingerprint matches\n\033[0m"
-if pkgutil --check-signature $PKG_PATH | /usr/bin/tr -d '\n' | /usr/bin/tr -d ' ' | /usr/bin/grep -q "SHA256Fingerprint:$CERT_SHA_FINGERPRINT"; then
+if pkgutil --check-signature "$PKG_PATH" | /usr/bin/tr -d '\n' | /usr/bin/tr -d ' ' | /usr/bin/grep -q "SHA256Fingerprint:$CERT_SHA_FINGERPRINT"; then
     printf "\033[34mDeveloper Certificate Fingerprint matches.\n\033[0m"
 else
     printf "\033[31m Developer Certificate Fingerprint does not match. Please contact support@vanta.com \033[0m\n"
@@ -87,17 +87,17 @@ fi
 printf "\033[34m\n* Installing the Vanta Agent. You might be asked for your password...\n\033[0m"
 $SUDO launchctl setenv VANTA_KEY "$VANTA_KEY"
 $SUDO launchctl setenv VANTA_OWNER_EMAIL "$VANTA_OWNER_EMAIL"
-$SUDO /usr/sbin/installer -pkg $PKG_PATH -target / >/dev/null
+$SUDO /usr/sbin/installer -pkg "$PKG_PATH" -target / >/dev/null
 $SUDO launchctl unsetenv VANTA_KEY
 $SUDO launchctl unsetenv VANTA_OWNER_EMAIL
-rm -f $PKG_PATH
+rm -f "$PKG_PATH"
 
 ##
 # check if the agent is running
 # return val 0 means running,
 # return val 2 means running but needs to register
 ##
-$SUDO /usr/local/vanta/vanta-cli status || [ $? == 2 ]
+$SUDO /usr/local/vanta/vanta-cli status || [ "$?" == 2 ]
 
 printf "\033[32m
 Your Agent is running properly. It will continue to run in the


### PR DESCRIPTION
Use || as or operator instead of -o which can have incorrect results and is deprecated. Use -n instead of double negation  '! -z'. Quote variables to prevent word splitting and whitespace problems