### PR TITLE
Update to 2.3.5 and remove deprecated platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,19 +20,6 @@ jobs:
       - name: Check that it's running correctly
         run: /var/vanta/vanta-cli status
 
-  build-amazonlinux:
-    runs-on: ubuntu-latest
-
-    container: amazonlinux
-    steps:
-      - uses: actions/checkout@v1
-      - name: Test install on Ubuntu
-        run: | # system manager issues in docker can be ignored for now
-          chmod +x ./install-linux.sh
-          VANTA_SKIP_REGISTRATION_CHECK=1 VANTA_KEY=FAKEKEY ./install-linux.sh
-      - name: Check that the directory exists
-        run: ls /var/vanta
-
   build-macos:
     runs-on: macos-latest
 

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -5,9 +5,9 @@ set -e
 # VANTA_KEY (the Vanta per-domain secret key)
 # VANTA_OWNER_EMAIL (the email of the person who owns this computer. Ignored if VANTA_KEY is missing.)
 
-PKG_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.3.4/vanta-universal.pkg"
+PKG_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.3.5/vanta-universal.pkg"
 # Checksum needs to be updated when PKG_URL is updated.
-CHECKSUM="ebd64bd170d7f3431b5b7e5144f1e8497be0e16b99e294ab49592c631064b2f1"
+CHECKSUM="b198607c12ef09afee7e0bf6e32f4369343c0010583b11ccf2846aa9ebaa6ac8"
 DEVELOPER_ID="Vanta Inc (632L25QNV4)"
 CERT_SHA_FINGERPRINT="D90D17FA20360BC635BC1A59B9FA5C6F9C9C2D4915711E4E0C182AA11E772BEF"
 PKG_PATH="$(mktemp -d)/vanta.pkg"


### PR DESCRIPTION
- Update download links and checksums to v2.3.5
- Clean up code related to deprecated Linux platforms; the Agent only supports Debian variants -- https://help.vanta.com/hc/en-us/articles/360060472372-Troubleshooting-the-Vanta-Agent-on-Linux-Machines