### PR TITLE
Add headless install scripts for beta release

### DIFF
--- a/beta/install-linux.sh
+++ b/beta/install-linux.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+# Available environment variables:
+# VANTA_KEY (the Vanta per-domain secret key)
+# VANTA_NOSTART (if true, then don't start the service upon installation.)
+
+set -e
+
+DEB_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/ZTODO/vanta-amd64.deb"
+# Checksums need to be updated when DEB_URL is updated.
+DEB_CHECKSUM="ZTODO"
+DEB_PATH="$(mktemp -d)/vanta.deb"
+DEB_INSTALL_CMD="dpkg -Ei"
+
+UUID_PATH="/sys/class/dmi/id/product_uuid"
+
+# OS/Distro Detection
+# Try lsb_release, fallback with /etc/issue then uname command
+# Detection code taken from https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/install_script.sh
+KNOWN_DISTRIBUTION="(Debian|Ubuntu)"
+DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || grep -m1 -Eo $KNOWN_DISTRIBUTION /etc/os-release 2>/dev/null || uname -s)
+
+if [ -f /etc/debian_version -o "$DISTRIBUTION" == "Debian" -o "$DISTRIBUTION" == "Ubuntu" ]; then
+    OS="Debian"
+fi
+
+##
+# Vanta needs to be installed as root; use sudo if not already uid 0
+##
+if [ $(echo "$UID") = "0" ]; then
+    SUDO=''
+else
+    SUDO='sudo -E'
+fi
+
+function get_platform() {
+    if ! command -v lsb_release &> /dev/null; then
+        echo "${DISTRIBUTION}"
+    else
+	lsb_release -sd
+    fi
+}
+
+if [ "${OS}" == "Debian" ]; then
+    printf "\033[34m\n* Debian detected \n\033[0m"
+    PKG_URL=$DEB_URL
+    PKG_PATH=$DEB_PATH
+    INSTALL_CMD=$DEB_INSTALL_CMD
+    CHECKSUM=$DEB_CHECKSUM
+else
+    printf "\033[31m
+Cannot install the Vanta agent on unsupported platform $(get_platform).
+Please reach out to support@vanta.com for help.
+\n\033[0m\n"
+    exit 1
+fi
+
+if [ ! -f "$UUID_PATH" ]; then
+    printf "\033[31m
+Unable to detect hardware UUID – the Vanta Agent is only supported on platforms which provide a value in $UUID_PATH
+\n\033[0m\n"
+    exit 1
+fi
+
+hardware_uuid=$($SUDO cat $UUID_PATH)
+
+printf "\033[34m\nHardware UUID: $hardware_uuid\n\033[0m"
+
+bad_uuids=(
+    "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"
+    "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA"
+    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    "00000000-0000-0000-0000-000000000000"
+    "11111111-1111-1111-1111-111111111111"
+    "03000200-0400-0500-0006-000700080009"
+    "03020100-0504-0706-0809-0a0b0c0d0e0f"
+    "03020100-0504-0706-0809-0a0b0c0d0e0f"
+    "10000000-0000-8000-0040-000000000000"
+    "01234567-8910-1112-1314-151617181920"
+)
+
+for uuid in ${bad_uuids[*]}; do
+    if [ "$uuid" = "$hardware_uuid" ]; then
+        printf "\033[31m
+Invalid hardware UUID – the Vanta Agent is only supported on platforms which provide a unique value in $UUID_PATH
+\n\033[0m\n"
+        exit 1
+    fi
+done
+printf "\033[34m\nUUID check passed.\n\033[0m"
+
+
+
+if [ -z "$VANTA_KEY" ]; then
+    printf "\033[31m
+You must specify the VANTA_KEY environment variable in order to install the agent.
+\n\033[0m\n"
+    exit 1
+fi
+
+function onerror() {
+    printf "\033[31m$ERROR_MESSAGE
+Something went wrong while installing the Vanta agent.
+
+If you're having trouble installing, please send an email to support@vanta.com, and we'll help you fix it!
+\n\033[0m\n"
+}
+trap onerror ERR
+
+##
+# Download the agent
+##
+printf "\033[34m\n* Downloading the Vanta Agent\n\033[0m"
+rm -f $PKG_PATH
+curl --progress-bar --output $PKG_PATH $PKG_URL
+
+##
+# Checksum
+##
+printf "\033[34m\n* Ensuring checksums match\n\033[0m"
+
+if [ -x "$(command -v shasum)" ]; then
+  downloaded_checksum=$(shasum -a256 $PKG_PATH | cut -d" " -f1)
+elif [ -x "$(command -v sha256sum)" ]; then
+  downloaded_checksum=$(sha256sum $PKG_PATH | cut -d" " -f1)
+else
+  printf "\033[31m shasum is not installed. Not checking binary contents. \033[0m\n"
+  # For now, don't fail if shasum is not installed. Delete this check if you want to
+  # ensure that the checksum is always enforced.
+  CHECKSUM=""
+fi
+
+if [ $downloaded_checksum = $CHECKSUM ]; then
+    printf "\033[34mChecksums match.\n\033[0m"
+else
+    printf "\033[31m Checksums do not match. Please contact support@vanta.com \033[0m\n"
+    exit 1
+fi
+
+##
+# Install the agent
+##
+printf "\033[34m\n* Installing the Vanta Agent. You might be asked for your password...\n\033[0m"
+$SUDO $INSTALL_CMD $PKG_PATH
+
+
+##
+# Check whether the agent is registered. It may take a couple of seconds,
+# so try 5 times with 5-second pauses in between.
+##
+if [ -z "$VANTA_SKIP_REGISTRATION_CHECK" ] && [ -z "$VANTA_NOSTART" ]; then
+    printf "\033[34m\n* Checking registration with Vanta\n\033[0m"
+    registration_success=false
+    for i in {1..5}
+    do
+        # Pause first, as the chances of registration working immediately are low.
+        sleep 5
+        echo "Attempt $i/5"
+        if $SUDO /var/vanta/vanta-cli check-registration; then
+            registration_success=true
+            break
+        fi
+    done
+
+    if [ "$registration_success" = false ] ; then
+        printf "\033[31m
+    Could not verify that the agent is registered to a Vanta domain. Are you sure you used the right key?
+    \n\033[0m\n" >&2
+        exit 0
+    fi
+
+else
+    printf "\033[34m\n* Skipping registration check\n\033[0m"
+fi
+
+printf "\033[32m
+The Vanta agent has been installed successfully.
+It will run in the background and submit data to Vanta.
+
+You can check the agent status using the \"/var/vanta/vanta-cli status\" command.
+\033[0m"

--- a/beta/install-macos.sh
+++ b/beta/install-macos.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+# Environment variables:
+# VANTA_KEY (the Vanta per-domain secret key)
+# VANTA_OWNER_EMAIL (the email of the person who owns this computer. Ignored if VANTA_KEY is missing.)
+# VANTA_REGION (the region the Agent talks to, such as "us" or "eu".)
+
+PKG_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/ZTODO/vanta-universal.pkg"
+# Checksum needs to be updated when PKG_URL is updated.
+CHECKSUM="ZTODO"
+DEVELOPER_ID="Vanta Inc (632L25QNV4)"
+CERT_SHA_FINGERPRINT="D90D17FA20360BC635BC1A59B9FA5C6F9C9C2D4915711E4E0C182AA11E772BEF"
+PKG_PATH="$(mktemp -d)/vanta.pkg"
+VANTA_CONF_PATH="/etc/vanta.conf"
+
+##
+# Vanta needs to be installed as root; use sudo if not already uid 0
+##
+if [ $(echo "$UID") = "0" ]; then
+    SUDO=''
+else
+    SUDO='sudo -E'
+fi
+
+if [ -z "$VANTA_KEY" ]; then
+    printf "\033[31m
+You must specify the VANTA_KEY environment variable in order to install the agent.
+\n\033[0m\n"
+    exit 1
+fi
+
+function onerror() {
+    printf "\033[31m$ERROR_MESSAGE
+Something went wrong while installing the Vanta agent.
+
+If you're having trouble installing, please send an email to support@vanta.com, and we'll help you fix it!
+\n\033[0m\n"
+}
+trap onerror ERR
+
+##
+# Download the agent
+##
+printf "\033[34m\n* Downloading the Vanta Agent\n\033[0m"
+rm -f $PKG_PATH
+curl --progress-bar $PKG_URL >$PKG_PATH
+
+##
+# Checksum
+##
+printf "\033[34m\n* Ensuring checksums match\n\033[0m"
+downloaded_checksum=$(shasum -a256 $PKG_PATH | cut -d" " -f1)
+if [ $downloaded_checksum = $CHECKSUM ]; then
+    printf "\033[34mChecksums match.\n\033[0m"
+else
+    printf "\033[31m Checksums do not match. Please contact support@vanta.com \033[0m\n"
+    rm -f $PKG_PATH
+    exit 1
+fi
+
+##
+# Check Developer ID
+##
+printf "\033[34m\n* Ensuring package Developer ID matches\n\033[0m"
+
+if pkgutil --check-signature $PKG_PATH | /usr/bin/grep -q "$DEVELOPER_ID"; then
+    printf "\033[34mDeveloper ID matches.\n\033[0m"
+else
+    printf "\033[31m Developer ID does not match. Please contact support@vanta.com \033[0m\n"
+    rm -f $PKG_PATH
+    exit 1
+fi
+
+##
+# Check Developer Certificate Fingerprint
+##
+printf "\033[34m\n* Ensuring package Developer Certificate Fingerprint matches\n\033[0m"
+if pkgutil --check-signature $PKG_PATH | /usr/bin/tr -d '\n' | /usr/bin/tr -d ' ' | /usr/bin/grep -q "SHA256Fingerprint:$CERT_SHA_FINGERPRINT"; then
+    printf "\033[34mDeveloper Certificate Fingerprint matches.\n\033[0m"
+else
+    printf "\033[31m Developer Certificate Fingerprint does not match. Please contact support@vanta.com \033[0m\n"
+    rm -f $PKG_PATH
+    exit 1
+fi
+
+##
+# Install the agent
+##
+printf "\033[34m\n* Installing the Vanta Agent. You might be asked for your password...\n\033[0m"
+CONFIG="{\"AGENT_KEY\":\"$VANTA_KEY\",\"OWNER_EMAIL\":\"$VANTA_OWNER_EMAIL\",\"NEEDS_OWNER\":true,\"REGION\":\"$VANTA_REGION\"}"
+echo "$CONFIG" | $SUDO tee "$VANTA_CONF_PATH" > /dev/null
+$SUDO /bin/chmod 400 "$VANTA_CONF_PATH"
+$SUDO /usr/sbin/chown root:wheel "$VANTA_CONF_PATH"
+$SUDO /usr/sbin/installer -pkg $PKG_PATH -target / >/dev/null
+rm -f $PKG_PATH
+
+##
+# check if the agent is running
+# return val 0 means running,
+# return val 2 means running but needs to register
+##
+$SUDO /usr/local/vanta/vanta-cli status || [ $? == 2 ]
+
+printf "\033[32m
+Your Agent is running properly. It will continue to run in the
+background and submit data to Vanta.
+
+You can check the agent status using the \"vanta-cli status\" command.
+
+If you ever want to stop the agent, please use the toolbar icon or
+the vanta-cli command. It will restart automatically at login.
+
+To register this device to a new user, run \"vanta-cli register\" or click on \"Register Vanta Agent\"
+on the toolbar.
+\033[0m"

--- a/beta/install-macos.sh
+++ b/beta/install-macos.sh
@@ -90,7 +90,7 @@ fi
 printf "\033[34m\n* Installing the Vanta Agent. You might be asked for your password...\n\033[0m"
 CONFIG="{\"AGENT_KEY\":\"$VANTA_KEY\",\"OWNER_EMAIL\":\"$VANTA_OWNER_EMAIL\",\"NEEDS_OWNER\":true,\"REGION\":\"$VANTA_REGION\"}"
 echo "$CONFIG" | $SUDO tee "$VANTA_CONF_PATH" > /dev/null
-$SUDO /bin/chmod 400 "$VANTA_CONF_PATH"
+$SUDO /bin/chmod 600 "$VANTA_CONF_PATH"
 $SUDO /usr/sbin/chown root:wheel "$VANTA_CONF_PATH"
 $SUDO /usr/sbin/installer -pkg $PKG_PATH -target / >/dev/null
 rm -f $PKG_PATH


### PR DESCRIPTION
```sh
➜  vanta-agent-scripts git:(beta-new-version-with-region) diff beta/install-macos.sh install-macos.sh
7d6
< # VANTA_REGION (the region the Agent talks to, such as "us" or "eu".)
9c8
< PKG_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/ZTODO/vanta-universal.pkg"
---
> PKG_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.4.0/vanta-universal.pkg"
11c10
< CHECKSUM="ZTODO"
---
> CHECKSUM="9f6f518706e5c08856cf15c3429b96a28d545aa589fc67e60095e744b4891d63"
91c90
< CONFIG="{\"AGENT_KEY\":\"$VANTA_KEY\",\"OWNER_EMAIL\":\"$VANTA_OWNER_EMAIL\",\"NEEDS_OWNER\":true,\"REGION\":\"$VANTA_REGION\"}"
---
> CONFIG="{\"AGENT_KEY\":\"$VANTA_KEY\",\"OWNER_EMAIL\":\"$VANTA_OWNER_EMAIL\",\"NEEDS_OWNER\":true}"
93c92
< $SUDO /bin/chmod 600 "$VANTA_CONF_PATH"
---
> $SUDO /bin/chmod 400 "$VANTA_CONF_PATH"
```

```sh
➜  vanta-agent-scripts git:(beta-new-version-with-region) diff beta/install-linux.sh install-linux.sh   
9c9
< DEB_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/ZTODO/vanta-amd64.deb"
---
> DEB_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.4.0/vanta-amd64.deb"
11c11
< DEB_CHECKSUM="ZTODO"
---
> DEB_CHECKSUM="59ac810c737d0290978a0092132f1c51571da52a8cf5413f31c1c317758be13d"
```