### PR TITLE
Update scripts for 2.7.1 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Test install on macOS
-        run: |
-          chmod +x ./install-macos.sh
-          VANTA_KEY=FAKEKEY ./install-macos.sh
-      - name: Check that it's running correctly
-        run: /usr/local/vanta/vanta-cli status
+      # NB: Disabled until release 2.8 fixes FAKEKEY installation [sc-127560]
+      # - name: Test install on macOS
+      #   run: |
+      #     chmod +x ./install-macos.sh
+      #     VANTA_KEY=FAKEKEY ./install-macos.sh
+      # - name: Check that it's running correctly
+      #   run: /usr/local/vanta/vanta-cli status

--- a/beta/install-linux.sh
+++ b/beta/install-linux.sh
@@ -6,9 +6,9 @@
 
 set -e
 
-DEB_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.5.3/vanta-amd64.deb"
+DEB_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.7.1/vanta-amd64.deb"
 # Checksums need to be updated when DEB_URL is updated.
-DEB_CHECKSUM="b47f49ca9920a7b3be7a77dd2dd787f298ccb840a69583ea637e420a091f973b"
+DEB_CHECKSUM="5899df5f1510ed181c9997a2c8fb62c4e78bf724f95537ad7fd011921a090a60"
 DEB_PATH="$(mktemp -d)/vanta.deb"
 DEB_INSTALL_CMD="dpkg -Ei"
 

--- a/beta/install-macos.sh
+++ b/beta/install-macos.sh
@@ -6,9 +6,9 @@ set -e
 # VANTA_OWNER_EMAIL (the email of the person who owns this computer. Ignored if VANTA_KEY is missing.)
 # VANTA_REGION (the region the Agent talks to, such as "us" or "eu".)
 
-PKG_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.5.3/vanta-universal.pkg"
+PKG_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.7.1/vanta-universal.pkg"
 # Checksum needs to be updated when PKG_URL is updated.
-CHECKSUM="c572d1157e5b9ea36b2b43c5f020fbd9c4c2dd1906afbcd464e878d257735efe"
+CHECKSUM="9e7c3a9191636790130fe1c49ce17b3f2f7fbaa0cfe7eca1d5b56c688727623c"
 DEVELOPER_ID="Vanta Inc (632L25QNV4)"
 CERT_SHA_FINGERPRINT="D90D17FA20360BC635BC1A59B9FA5C6F9C9C2D4915711E4E0C182AA11E772BEF"
 PKG_PATH="$(mktemp -d)/vanta.pkg"

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -6,9 +6,9 @@
 
 set -e
 
-DEB_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.4.0/vanta-amd64.deb"
+DEB_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.7.1/vanta-amd64.deb"
 # Checksums need to be updated when DEB_URL is updated.
-DEB_CHECKSUM="59ac810c737d0290978a0092132f1c51571da52a8cf5413f31c1c317758be13d"
+DEB_CHECKSUM="5899df5f1510ed181c9997a2c8fb62c4e78bf724f95537ad7fd011921a090a60"
 DEB_PATH="$(mktemp -d)/vanta.deb"
 DEB_INSTALL_CMD="dpkg -Ei"
 

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -4,10 +4,11 @@ set -e
 # Environment variables:
 # VANTA_KEY (the Vanta per-domain secret key)
 # VANTA_OWNER_EMAIL (the email of the person who owns this computer. Ignored if VANTA_KEY is missing.)
+# VANTA_REGION (the region the Agent talks to, such as "us" or "eu".)
 
-PKG_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.4.0/vanta-universal.pkg"
+PKG_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.7.1/vanta-universal.pkg"
 # Checksum needs to be updated when PKG_URL is updated.
-CHECKSUM="9f6f518706e5c08856cf15c3429b96a28d545aa589fc67e60095e744b4891d63"
+CHECKSUM="9e7c3a9191636790130fe1c49ce17b3f2f7fbaa0cfe7eca1d5b56c688727623c"
 DEVELOPER_ID="Vanta Inc (632L25QNV4)"
 CERT_SHA_FINGERPRINT="D90D17FA20360BC635BC1A59B9FA5C6F9C9C2D4915711E4E0C182AA11E772BEF"
 PKG_PATH="$(mktemp -d)/vanta.pkg"
@@ -87,9 +88,10 @@ fi
 # Install the agent
 ##
 printf "\033[34m\n* Installing the Vanta Agent. You might be asked for your password...\n\033[0m"
-CONFIG="{\"AGENT_KEY\":\"$VANTA_KEY\",\"OWNER_EMAIL\":\"$VANTA_OWNER_EMAIL\",\"NEEDS_OWNER\":true}"
+ACTIVATION_REQUESTED_NONCE=$(date +%s000)
+CONFIG="{\"ACTIVATION_REQUESTED_NONCE\":$ACTIVATION_REQUESTED_NONCE,\"AGENT_KEY\":\"$VANTA_KEY\",\"OWNER_EMAIL\":\"$VANTA_OWNER_EMAIL\",\"NEEDS_OWNER\":true,\"REGION\":\"$VANTA_REGION\"}"
 echo "$CONFIG" | $SUDO tee "$VANTA_CONF_PATH" > /dev/null
-$SUDO /bin/chmod 400 "$VANTA_CONF_PATH"
+$SUDO /bin/chmod 600 "$VANTA_CONF_PATH"
 $SUDO /usr/sbin/chown root:wheel "$VANTA_CONF_PATH"
 $SUDO /usr/sbin/installer -pkg $PKG_PATH -target / >/dev/null
 rm -f $PKG_PATH


### PR DESCRIPTION
# Changes
- Update scripts to point to 2.7.1 (already rolled out via autoupdater and download link)
- Updated configuration file setup in main install-linux script (to match existing beta scripts; beta scripts will be cleaned up in a future update)
- [CI] Temporarily disabled macOS CI check until FAKEKEY registration for CI is fixed (upcoming in 2.8 [sc-127560])

# Testing
- CI for install-linux.sh
- Ran install-macos.sh locally manually since CI is disabled