### PR TITLE
Update to 2.9.0 release

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -6,9 +6,9 @@
 
 set -e
 
-DEB_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.8.1/vanta-amd64.deb"
+DEB_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.9.0/vanta-amd64.deb"
 # Checksums need to be updated when DEB_URL is updated.
-DEB_CHECKSUM="7bec7ee8f51964037f7b8ed7923e6adc3d0112ae4249eef52fef508b6d0559c5"
+DEB_CHECKSUM="a138882d035770edeb3e65dd2e1b9e430fa1da9b2a314730f94997694ef4518b"
 DEB_PATH="$(mktemp -d)/vanta.deb"
 DEB_INSTALL_CMD="dpkg -Ei"
 

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -6,9 +6,9 @@ set -e
 # VANTA_OWNER_EMAIL (the email of the person who owns this computer. Ignored if VANTA_KEY is missing.)
 # VANTA_REGION (the region the Agent talks to, such as "us" or "eu".)
 
-PKG_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.8.1/vanta-universal.pkg"
+PKG_URL="https://vanta-agent-repo.s3.amazonaws.com/targets/versions/2.9.0/vanta-universal.pkg"
 # Checksum needs to be updated when PKG_URL is updated.
-CHECKSUM="31159006453a4352c41eaeab9bbd527fa9af00cdaf5268e06c6def20f52ef7cf"
+CHECKSUM="8f92149bfdc26e29815ff8c46e2c95424c538a096742e444d7feb1fbafaa0aa8"
 DEVELOPER_ID="Vanta Inc (632L25QNV4)"
 CERT_SHA_FINGERPRINT="D90D17FA20360BC635BC1A59B9FA5C6F9C9C2D4915711E4E0C182AA11E772BEF"
 PKG_PATH="$(mktemp -d)/vanta.pkg"


### PR DESCRIPTION
Update scripts to install the 2.9.0 release

Test plan:
CI will validate checksums and installation