### PR TITLE
Update scripts to point to agent version 2.12.0

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -6,9 +6,9 @@
 
 set -e
 
-DEB_URL="https://agent-downloads.vanta.com/targets/versions/2.11.0/vanta-amd64.deb"
+DEB_URL="https://agent-downloads.vanta.com/targets/versions/2.12.0/vanta-amd64.deb"
 # Checksums need to be updated when DEB_URL is updated.
-DEB_CHECKSUM="8763c60427111fc84a20662c92aa3b80b35b01825108220b24653e4d25e39d26"
+DEB_CHECKSUM="17312a1c1195bed192216c6240a322581bb569c0bd3a88de42b587203362d403"
 DEB_PATH="$(mktemp -d)/vanta.deb"
 DEB_INSTALL_CMD="dpkg -Ei"
 

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -6,9 +6,9 @@ set -e
 # VANTA_OWNER_EMAIL (the email of the person who owns this computer)
 # VANTA_REGION (the region the Agent talks to, such as "us", "eu" or "aus".)
 
-PKG_URL="https://agent-downloads.vanta.com/targets/versions/2.11.0/vanta-universal.pkg"
+PKG_URL="https://agent-downloads.vanta.com/targets/versions/2.12.0/vanta-universal.pkg"
 # Checksum needs to be updated when PKG_URL is updated.
-CHECKSUM="3ecd027dcc6079af06c3372fd0bee1d36f5304c5465d64c97779c6c05478323b"
+CHECKSUM="4e49a169593c599f2e2fc2e083a4fc67f6278905ff0dfd63acfc709c174d7190"
 DEVELOPER_ID="Vanta Inc (632L25QNV4)"
 CERT_SHA_FINGERPRINT="D90D17FA20360BC635BC1A59B9FA5C6F9C9C2D4915711E4E0C182AA11E772BEF"
 PKG_PATH="$(mktemp -d)/vanta.pkg"


### PR DESCRIPTION
# Changes
* Update scripts to point to agent version 2.12.0

# Testing
CI will validate checksums and installation