### PR TITLE
Update scripts to point to agent version 2.13.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Test install on Ubuntu
         run: |
           chmod +x ./install-linux.sh
-          VANTA_SKIP_REGISTRATION_CHECK=1 VANTA_KEY=FAKEKEY ./install-linux.sh
+          VANTA_SKIP_REGISTRATION_CHECK=1 VANTA_KEY=FAKEKEY VANTA_OWNER_EMAIL=fake-email@vanta.com VANTA_REGION=us ./install-linux.sh
       - name: Check that it's running correctly
         run: /var/vanta/vanta-cli status
 

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -2,13 +2,15 @@
 
 # Available environment variables:
 # VANTA_KEY (the Vanta per-domain secret key)
+# VANTA_OWNER_EMAIL (the email of the person who owns this computer)
+# VANTA_REGION (the region the Agent talks to, such as "us", "eu" or "aus".)
 # VANTA_NOSTART (if true, then don't start the service upon installation.)
 
 set -e
 
-DEB_URL="https://agent-downloads.vanta.com/targets/versions/2.12.0/vanta-amd64.deb"
+DEB_URL="https://agent-downloads.vanta.com/targets/versions/2.13.0/vanta-amd64.deb"
 # Checksums need to be updated when DEB_URL is updated.
-DEB_CHECKSUM="17312a1c1195bed192216c6240a322581bb569c0bd3a88de42b587203362d403"
+DEB_CHECKSUM="aced177e5d4c0d47490722ddde41aa00fe6ee8e8316da3b9309a29ae05b57ad7"
 DEB_PATH="$(mktemp -d)/vanta.deb"
 DEB_INSTALL_CMD="dpkg -Ei"
 
@@ -95,6 +97,18 @@ printf "\033[34m\nUUID check passed.\n\033[0m"
 if [ -z "$VANTA_KEY" ]; then
     printf "\033[31m
 You must specify the VANTA_KEY environment variable in order to install the agent.
+\n\033[0m\n"
+    exit 1
+fi
+if [ -z "$VANTA_OWNER_EMAIL" ]; then
+    printf "\033[31m
+You must specify the VANTA_OWNER_EMAIL environment variable in order to install the agent.
+\n\033[0m\n"
+    exit 1
+fi
+if [ -z "$VANTA_REGION" ]; then
+    printf "\033[31m
+You must specify the VANTA_REGION environment variable in order to install the agent.
 \n\033[0m\n"
     exit 1
 fi

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -6,9 +6,9 @@ set -e
 # VANTA_OWNER_EMAIL (the email of the person who owns this computer)
 # VANTA_REGION (the region the Agent talks to, such as "us", "eu" or "aus".)
 
-PKG_URL="https://agent-downloads.vanta.com/targets/versions/2.12.0/vanta-universal.pkg"
+PKG_URL="https://agent-downloads.vanta.com/targets/versions/2.13.0/vanta-universal.pkg"
 # Checksum needs to be updated when PKG_URL is updated.
-CHECKSUM="4e49a169593c599f2e2fc2e083a4fc67f6278905ff0dfd63acfc709c174d7190"
+CHECKSUM="54bf5ab58f7362f8058d0c903e00cc6347083e16aace7462518f196a3e145560"
 DEVELOPER_ID="Vanta Inc (632L25QNV4)"
 CERT_SHA_FINGERPRINT="D90D17FA20360BC635BC1A59B9FA5C6F9C9C2D4915711E4E0C182AA11E772BEF"
 PKG_PATH="$(mktemp -d)/vanta.pkg"


### PR DESCRIPTION
# Changes
* Update scripts to point to agent version 2.13.0
* Updated linux installation script to require for VANTA_REGION and VANTA_OWNER_EMAIL

# Testing
CI will validate checksums and installation