### PR TITLE
Convert CI to matrix strategy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,26 +8,28 @@ on:
   pull_request:
 
 jobs:
-  build-ubuntu:
-    runs-on: ubuntu-latest
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false  # Ensures a failure on one operating system doesn't cancel the other's test
+      matrix:
+        include:
+          - os: ubuntu-latest
+            script: ./install-linux.sh
+            bin_path: /var/vanta/vanta-cli
+          - os: macos-latest
+            script: ./install-macos.sh
+            bin_path: /usr/local/vanta/vanta-cli
 
     steps:
-      - uses: actions/checkout@v1
-      - name: Test install on Ubuntu
-        run: |
-          chmod +x ./install-linux.sh
-          VANTA_SKIP_REGISTRATION_CHECK=1 VANTA_KEY=FAKEKEY VANTA_OWNER_EMAIL=fake-email@vanta.com VANTA_REGION=us ./install-linux.sh
-      - name: Check that it's running correctly
-        run: /var/vanta/vanta-cli status
+      - name: Checkout
+        uses: actions/checkout@v6
 
-  build-macos:
-    runs-on: macos-13
-    
-    steps:
-      - uses: actions/checkout@v1
-      - name: Test install on macOS
+      - name: Test install
         run: |
-          chmod +x ./install-macos.sh
-          VANTA_KEY=FAKEKEY VANTA_OWNER_EMAIL=fake-email@vanta.com VANTA_REGION=us ./install-macos.sh
+          chmod +x ${{ matrix.script }}
+          VANTA_SKIP_REGISTRATION_CHECK=1 VANTA_KEY=FAKEKEY VANTA_OWNER_EMAIL=fake-email@vanta.com VANTA_REGION=us ${{ matrix.script }}
+
       - name: Check that it's running correctly
-        run: /usr/local/vanta/vanta-cli status
+        run: ${{ matrix.bin_path }} status

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build (${{ matrix.os }})


### PR DESCRIPTION
Converting the GitHub Actions workflow here to use a matrix strategy, reference https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/run-job-variations.

Also updates runner images and actions versions used to latest.

Example run on my fork - https://github.com/ScottBrenner/vanta-agent-scripts/actions/runs/21803335581