### PR TITLE
Fix for code scanning alert: Workflow does not contain permissions 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
In general, the fix is to add an explicit `permissions` block to the workflow (at the top level or per-job) restricting the `GITHUB_TOKEN` to the minimum needed. Here, the jobs only need to check out the repository, which requires `contents: read`. They don’t need to write to the repo or interact with issues, PRs, or other resources.

The best fix with minimal functional impact is to add a root-level `permissions` block right under the `name:` (or `on:`) key in `.github/workflows/main.yml`, setting `contents: read`. This automatically applies to both `build-ubuntu` and `build-macos` jobs, since they don’t have their own `permissions` blocks. No changes to steps or actions are needed. Concretely, you should edit `.github/workflows/main.yml` so that after line 1 (`name: CI`), you insert:

```yml
permissions:
  contents: read
```

This satisfies CodeQL’s recommendation and least-privilege principles without changing workflow behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
