### PR TITLE
Update scripts to point to agent version 2.16.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         run: /var/vanta/vanta-cli status
 
   build-macos:
-    runs-on: macos-13
+    runs-on: macos-latest
     
     steps:
       - uses: actions/checkout@v1

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -8,9 +8,9 @@
 
 set -e
 
-DEB_URL="https://agent-downloads.vanta.com/targets/versions/2.15.0/vanta-amd64.deb"
+DEB_URL="https://agent-downloads.vanta.com/targets/versions/2.16.1/vanta-amd64.deb"
 # Checksums need to be updated when DEB_URL is updated.
-DEB_CHECKSUM="02ba826388dee61aaf3e97f4bec61896620bc616754e7d107c0efcc79abd43a0"
+DEB_CHECKSUM="bb8eccb929b63dc7c7137fd35716a69d5e20b616ae200a89ae519c6d2d6cf7f1"
 DEB_PATH="$(mktemp -d)/vanta.deb"
 DEB_INSTALL_CMD="dpkg -Ei"
 

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -6,9 +6,9 @@ set -e
 # VANTA_OWNER_EMAIL (the email of the person who owns this computer)
 # VANTA_REGION (the region Vanta Device Monitor talks to, such as "us", "eu" or "aus".)
 
-PKG_URL="https://agent-downloads.vanta.com/targets/versions/2.15.0/vanta-universal.pkg"
+PKG_URL="https://agent-downloads.vanta.com/targets/versions/2.16.1/vanta-universal.pkg"
 # Checksum needs to be updated when PKG_URL is updated.
-CHECKSUM="f3cd509d9c0fb3042c02d485caf18194ba233dcaa037f51b736f84f2f2e68c64"
+CHECKSUM="66c71af348441c7efdb88d98fd43e8f9d401bd21976bcb0ff7b1a4fb56a9628c"
 DEVELOPER_ID="Vanta Inc (632L25QNV4)"
 CERT_SHA_FINGERPRINT="48893790A4B4FB1684589E3AC91CC25EDD5284F9E7BA07025CBDF2814FE74984"
 PKG_PATH="$(mktemp -d)/vanta.pkg"


### PR DESCRIPTION
# Changes
* Updated scripts to point to agent version 2.16.1
* Updated macos runner version to macos-latest

# Testing
CI will validate checksums and installation