### PR TITLE
fix: explicit env var passthrough for sudo on env_reset distros

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -32,7 +32,7 @@ fi
 if [ $(echo "$UID") = "0" ]; then
     SUDO=''
 else
-    SUDO='sudo -E'
+    SUDO='sudo'
 fi
 
 function get_platform() {
@@ -156,7 +156,12 @@ fi
 # Install Vanta Device Monitor
 ##
 printf "\033[34m\n* Installing Vanta Device Monitor. You might be asked for your password...\n\033[0m"
-$SUDO $INSTALL_CMD $PKG_PATH
+$SUDO env \
+    VANTA_KEY="$VANTA_KEY" \
+    VANTA_OWNER_EMAIL="$VANTA_OWNER_EMAIL" \
+    VANTA_REGION="$VANTA_REGION" \
+    ${VANTA_NOSTART:+VANTA_NOSTART="$VANTA_NOSTART"} \
+    $INSTALL_CMD $PKG_PATH
 
 
 ##


### PR DESCRIPTION
## Problem

On distros with `env_reset` in sudoers (like we've seen in Ubuntu 26.04 as reported: https://vanta.atlassian.net/browse/PER-10076), `sudo -E` does not reliably pass through `VANTA_KEY`, `VANTA_OWNER_EMAIL`, or `VANTA_REGION`. The `env_reset` policy strips the environment regardless of the `-E` flag, so the `dpkg`/`rpm` postinst script never sees the required variables and installation fails silently.

## Solution

Replace `sudo -E` with plain `sudo` and explicitly forward only the required variables via `sudo env VAR=value ...`. This sidesteps `env_reset` entirely — the variables are passed as arguments to `env` rather than inherited through sudo.

`VANTA_NOSTART` is forwarded conditionally using shell parameter expansion so it is only included when set.

## Changes

- `install-linux.sh`: Replace `sudo -E` with `sudo` and pass env vars explicitly to the install command

Fixes PER-10076