### PR TITLE
Update Vanta agent to 2.18.0

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -8,9 +8,9 @@
 
 set -e
 
-DEB_URL="https://agent-downloads.vanta.com/targets/versions/2.17.2/vanta-amd64.deb"
+DEB_URL="https://agent-downloads.vanta.com/targets/versions/2.18.0/vanta-amd64.deb"
 # Checksums need to be updated when DEB_URL is updated.
-DEB_CHECKSUM="9ba315a2415c3a6e5a4f087bcd0d4268e016bcb999c7c7f0e594336cb163f6d3"
+DEB_CHECKSUM="0e6e584896237ad11ddaa5bd36de8d1b51a71ae93d84c95dd6b9b0ca7dc3f47d"
 DEB_PATH="$(mktemp -d)/vanta.deb"
 DEB_INSTALL_CMD="dpkg -Ei"
 

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -6,9 +6,9 @@ set -e
 # VANTA_OWNER_EMAIL (the email of the person who owns this computer)
 # VANTA_REGION (the region Vanta Device Monitor talks to, such as "us", "eu" or "aus".)
 
-PKG_URL="https://agent-downloads.vanta.com/targets/versions/2.17.2/vanta-universal.pkg"
+PKG_URL="https://agent-downloads.vanta.com/targets/versions/2.18.0/vanta-universal.pkg"
 # Checksum needs to be updated when PKG_URL is updated.
-CHECKSUM="d939f0d7d9bd1a51452e27fa4982668386aa5306198731c8214b34a30e9ac52f"
+CHECKSUM="cfc39535abaa8dac6bda27d77caa71dcf87b297c47fdcd54234a8eb2d084c13f"
 DEVELOPER_ID="Vanta Inc (632L25QNV4)"
 CERT_SHA_FINGERPRINT="48893790A4B4FB1684589E3AC91CC25EDD5284F9E7BA07025CBDF2814FE74984"
 PKG_PATH="$(mktemp -d)/vanta.pkg"


### PR DESCRIPTION
## Summary
- Update Linux and macOS installer download URLs to Vanta agent 2.18.0
- Update pinned SHA-256 checksums for the 2.18.0 artifacts

## Test plan
- bash -n install-linux.sh
- bash -n install-macos.sh
- Downloaded 2.18.0 Linux and macOS packages and computed SHA-256 checksums